### PR TITLE
feat: Port UI features from calculus-ui to template

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/redhat-ai-americas/ui-template/static"
+	"github.com/fips-agents/ui-template/static"
 )
 
 func main() {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redhat-ai-americas/ui-template/static"
+	"github.com/fips-agents/ui-template/static"
 )
 
 // buildMux creates the same ServeMux as main(), wired to the given backend URL

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/redhat-ai-americas/ui-template
+module github.com/fips-agents/ui-template
 
 go 1.22

--- a/static/app.js
+++ b/static/app.js
@@ -6,13 +6,254 @@
 let messages = [];
 let streaming = false;
 
+// -- Settings panel state ---------------------------------------------------
+let agentInfo = null;
+let userTemperature = null;  // null = use server default
+let userMaxTokens = null;
+let userTopP = null;
+let userTopK = null;
+let userFreqPenalty = null;
+let userPresencePenalty = null;
+let userRepPenalty = null;
+let userReasoningEffort = null;
+let userApiBase = null;  // null = use default (direct vLLM)
+let userResponsesApi = false;
+
+async function loadAgentInfo() {
+  try {
+    const resp = await fetch("/v1/agent-info");
+    if (!resp.ok) return;
+    agentInfo = await resp.json();
+    populateSettings();
+  } catch (e) {
+    console.warn("Could not load agent info:", e);
+  }
+}
+
+function populateSettings() {
+  if (!agentInfo) return;
+
+  // Model name in header subtitle
+  const modelNameEl = document.getElementById("model-name");
+  if (modelNameEl && agentInfo.model) {
+    // Show just the model's short name, e.g. "gpt-oss-20b" from "openai/RedHatAI/gpt-oss-20b"
+    const parts = agentInfo.model.name.split("/");
+    modelNameEl.textContent = parts[parts.length - 1];
+  }
+
+  // Model info section
+  const modelInfoEl = document.getElementById("model-info");
+  if (modelInfoEl && agentInfo.model) {
+    modelInfoEl.innerHTML =
+      '<div class="info-row"><span class="info-label">Name</span><span class="info-value">' +
+      agentInfo.model.name.split("/").pop() + '</span></div>' +
+      '<div class="info-row"><span class="info-label">Default Temperature</span><span class="info-value">' +
+      agentInfo.model.temperature + '</span></div>' +
+      '<div class="info-row"><span class="info-label">Default Max Tokens</span><span class="info-value">' +
+      agentInfo.model.max_tokens + '</span></div>';
+  }
+
+  // Set parameter controls to defaults
+  const tempSlider = document.getElementById("param-temperature");
+  const tempValue = document.getElementById("temp-value");
+  const maxTokensInput = document.getElementById("param-max-tokens");
+  if (tempSlider && agentInfo.model) {
+    tempSlider.value = agentInfo.model.temperature;
+    tempValue.textContent = agentInfo.model.temperature;
+  }
+  if (maxTokensInput && agentInfo.model) {
+    maxTokensInput.value = agentInfo.model.max_tokens;
+  }
+
+  const topPSlider = document.getElementById("param-top-p");
+  const topPValue = document.getElementById("top-p-value");
+  if (topPSlider) { topPValue.textContent = ""; }
+
+  const freqSlider = document.getElementById("param-freq-penalty");
+  const freqValue = document.getElementById("freq-penalty-value");
+  if (freqSlider) { freqSlider.value = 0; freqValue.textContent = "0"; }
+
+  const presSlider = document.getElementById("param-presence-penalty");
+  const presValue = document.getElementById("presence-penalty-value");
+  if (presSlider) { presSlider.value = 0; presValue.textContent = "0"; }
+
+  const repSlider = document.getElementById("param-rep-penalty");
+  const repValue = document.getElementById("rep-penalty-value");
+  if (repSlider) { repSlider.value = 1; repValue.textContent = "1"; }
+
+  // Backend selector
+  const backendSelect = document.getElementById("param-backend");
+  const responsesGroup = document.getElementById("responses-api-group");
+  const responsesCheckbox = document.getElementById("param-responses-api");
+  if (backendSelect && agentInfo.backends) {
+    // Show/hide Responses API option based on LlamaStack availability
+    if (agentInfo.backends.llamastack && agentInfo.backends.llamastack.responses_api) {
+      responsesCheckbox.disabled = false;
+      responsesGroup.querySelector(".param-hint").textContent = "";
+    }
+  }
+
+  // System prompt
+  const promptEl = document.getElementById("system-prompt");
+  if (promptEl) {
+    promptEl.textContent = agentInfo.system_prompt || "(none)";
+  }
+
+  // Tools list
+  const toolsListEl = document.getElementById("tools-list");
+  const toolsCountEl = document.getElementById("tools-count");
+  if (toolsListEl && agentInfo.tools) {
+    toolsCountEl.textContent = "(" + agentInfo.tools.length + ")";
+    toolsListEl.innerHTML = "";
+    for (const tool of agentInfo.tools) {
+      const details = document.createElement("details");
+      details.className = "tool-info";
+      const summary = document.createElement("summary");
+      summary.textContent = tool.name;
+      details.appendChild(summary);
+      const desc = document.createElement("p");
+      desc.className = "tool-description";
+      desc.textContent = tool.description;
+      details.appendChild(desc);
+      if (tool.parameters && tool.parameters.properties) {
+        const params = document.createElement("div");
+        params.className = "tool-params";
+        const keys = Object.keys(tool.parameters.properties);
+        params.textContent = "Parameters: " + keys.join(", ");
+        details.appendChild(params);
+      }
+      toolsListEl.appendChild(details);
+    }
+  }
+}
+
+function setupSettings() {
+  const btn = document.getElementById("settings-btn");
+  const panel = document.getElementById("settings-panel");
+  const overlay = document.getElementById("settings-overlay");
+  const closeBtn = document.getElementById("settings-close");
+
+  function toggle() {
+    const open = panel.classList.toggle("open");
+    overlay.classList.toggle("open", open);
+  }
+
+  if (btn) btn.addEventListener("click", toggle);
+  if (closeBtn) closeBtn.addEventListener("click", toggle);
+  if (overlay) overlay.addEventListener("click", toggle);
+
+  // Temperature slider
+  const tempSlider = document.getElementById("param-temperature");
+  const tempValue = document.getElementById("temp-value");
+  if (tempSlider) {
+    tempSlider.addEventListener("input", function () {
+      tempValue.textContent = this.value;
+      userTemperature = parseFloat(this.value);
+    });
+  }
+
+  // Max tokens input
+  const maxTokensInput = document.getElementById("param-max-tokens");
+  if (maxTokensInput) {
+    maxTokensInput.addEventListener("change", function () {
+      userMaxTokens = parseInt(this.value, 10) || null;
+    });
+  }
+
+  // Top P slider
+  const topPSlider = document.getElementById("param-top-p");
+  const topPValue = document.getElementById("top-p-value");
+  if (topPSlider) {
+    topPSlider.addEventListener("input", function () {
+      topPValue.textContent = this.value;
+      userTopP = parseFloat(this.value) || null;
+    });
+  }
+
+  // Top K
+  const topKInput = document.getElementById("param-top-k");
+  if (topKInput) {
+    topKInput.addEventListener("change", function () {
+      const v = parseInt(this.value, 10);
+      userTopK = (v > 0) ? v : null;
+    });
+  }
+
+  // Frequency penalty
+  const freqSlider = document.getElementById("param-freq-penalty");
+  const freqValue = document.getElementById("freq-penalty-value");
+  if (freqSlider) {
+    freqSlider.addEventListener("input", function () {
+      freqValue.textContent = this.value;
+      userFreqPenalty = parseFloat(this.value) || null;
+    });
+  }
+
+  // Presence penalty
+  const presSlider = document.getElementById("param-presence-penalty");
+  const presValue = document.getElementById("presence-penalty-value");
+  if (presSlider) {
+    presSlider.addEventListener("input", function () {
+      presValue.textContent = this.value;
+      userPresencePenalty = parseFloat(this.value) || null;
+    });
+  }
+
+  // Repetition penalty
+  const repSlider = document.getElementById("param-rep-penalty");
+  const repValue = document.getElementById("rep-penalty-value");
+  if (repSlider) {
+    repSlider.addEventListener("input", function () {
+      repValue.textContent = this.value;
+      const v = parseFloat(this.value);
+      userRepPenalty = (v !== 1.0) ? v : null;
+    });
+  }
+
+  // Reasoning effort
+  const reasoningSelect = document.getElementById("param-reasoning");
+  if (reasoningSelect) {
+    reasoningSelect.addEventListener("change", function () {
+      userReasoningEffort = this.value || null;
+    });
+  }
+
+  // Backend selector
+  const backendSelect = document.getElementById("param-backend");
+  const responsesGroup = document.getElementById("responses-api-group");
+  if (backendSelect) {
+    backendSelect.addEventListener("change", function () {
+      const val = this.value;
+      if (val === "llamastack" && agentInfo && agentInfo.backends && agentInfo.backends.llamastack) {
+        userApiBase = agentInfo.backends.llamastack.api_base;
+        responsesGroup.style.display = "block";
+      } else {
+        userApiBase = null;
+        responsesGroup.style.display = "none";
+        // Uncheck Responses API when switching away from LlamaStack
+        const cb = document.getElementById("param-responses-api");
+        if (cb) { cb.checked = false; userResponsesApi = false; }
+      }
+    });
+  }
+
+  // Responses API checkbox
+  const responsesCheckbox = document.getElementById("param-responses-api");
+  if (responsesCheckbox) {
+    responsesCheckbox.addEventListener("change", function () {
+      userResponsesApi = this.checked;
+    });
+  }
+}
+
 const messagesEl = document.getElementById("messages");
 const inputEl = document.getElementById("input");
 const sendBtn = document.getElementById("send-btn");
 const chatEl = document.getElementById("chat");
 
 async function init() {
-  // Server proxies /v1/* to the backend — no config discovery needed
+  setupSettings();
+  loadAgentInfo();
 }
 
 function appendMessage(role, content) {
@@ -37,6 +278,39 @@ function scrollToBottom() {
 }
 
 function renderContent(text) {
+  // Phase 0: Render LaTeX blocks directly to HTML via KaTeX (if loaded).
+  // We do this before HTML escaping so the TeX source isn't mangled.
+  // The rendered HTML is stored as a placeholder and restored after
+  // all markdown processing.
+  var latexBlocks = [];
+  if (typeof katex !== "undefined") {
+    // Display math: \[...\]
+    text = text.replace(/\\\[([\s\S]*?)\\\]/g, function (_, tex) {
+      var idx = latexBlocks.length;
+      var html;
+      try {
+        html = katex.renderToString(tex.trim(), { displayMode: true, throwOnError: false });
+        html = '<div class="katex-display-block">' + html + '</div>';
+      } catch (e) {
+        html = "\\[" + tex + "\\]";
+      }
+      latexBlocks.push(html);
+      return "\x00LATEX" + idx + "\x00";
+    });
+    // Inline math: \(...\)
+    text = text.replace(/\\\(([\s\S]*?)\\\)/g, function (_, tex) {
+      var idx = latexBlocks.length;
+      var html;
+      try {
+        html = katex.renderToString(tex.trim(), { displayMode: false, throwOnError: false });
+      } catch (e) {
+        html = "\\(" + tex + "\\)";
+      }
+      latexBlocks.push(html);
+      return "\x00LATEX" + idx + "\x00";
+    });
+  }
+
   // Escape HTML first
   var safe = text
     .replace(/&/g, "&amp;")
@@ -157,6 +431,9 @@ function renderContent(text) {
   result = result.replace(/\x00INLINE(\d+)\x00/g, function (_, idx) {
     return inlineCode[parseInt(idx, 10)];
   });
+  result = result.replace(/\x00LATEX(\d+)\x00/g, function (_, idx) {
+    return latexBlocks[parseInt(idx, 10)];
+  });
 
   return result;
 }
@@ -192,6 +469,8 @@ function createStreamRenderer(assistantEl) {
   let responseEl = null;
   let responseText = "";
   let responseIndicator = null;
+  let streamMetrics = null;     // server-sent metrics object
+  let rawChunks = [];
 
   // Per-tool state: index -> { pillEl, nameEl, statusEl, argsEl, resultEl, args, name, callId }
   const toolCalls = new Map();
@@ -202,7 +481,7 @@ function createStreamRenderer(assistantEl) {
     thinkingPanel.className = "thinking-panel";
     // Collapsed by default per design.
     const summary = document.createElement("summary");
-    summary.textContent = "Thinking…";
+    summary.textContent = "Thinking\u2026";
     thinkingPanel.appendChild(summary);
     thinkingContent = document.createElement("div");
     thinkingContent.className = "thinking-content";
@@ -229,14 +508,14 @@ function createStreamRenderer(assistantEl) {
 
   function startToolCall(index, callId, name) {
     ensureToolCallsContainer();
-    const pill = document.createElement("div");
+    const pill = document.createElement("details");
     pill.className = "tool-call running";
 
-    const header = document.createElement("div");
+    const header = document.createElement("summary");
     header.className = "tool-header";
     const icon = document.createElement("span");
     icon.className = "tool-icon";
-    icon.textContent = "⚙";
+    icon.textContent = "\u2699";
     const nameEl = document.createElement("span");
     nameEl.className = "tool-name";
     nameEl.textContent = name;
@@ -313,7 +592,11 @@ function createStreamRenderer(assistantEl) {
     scrollToBottom();
   }
 
-  function finalize() {
+  function setMetrics(metrics, usage) {
+    streamMetrics = { ...metrics, usage };
+  }
+
+  function finalize(clientTtft) {
     // Remove the streaming cursor.
     if (responseIndicator && responseIndicator.parentNode) {
       responseIndicator.parentNode.removeChild(responseIndicator);
@@ -327,6 +610,51 @@ function createStreamRenderer(assistantEl) {
     if (!responseText.trim() && !toolCalls.size && !thinkingPanel) {
       assistantEl.textContent = "(no response)";
     }
+
+    // Raw API response button -- always shown
+    const rawBtn = document.createElement("button");
+    rawBtn.className = "raw-response-btn";
+    rawBtn.textContent = "View Raw Response";
+    rawBtn.title = "View full API response chunks";
+    rawBtn.addEventListener("click", function () {
+      showRawResponse(rawChunks);
+    });
+    assistantEl.appendChild(rawBtn);
+
+    // Render metrics bar if we have data.
+    const m = streamMetrics;
+    if (!m) return;
+
+    const bar = document.createElement("div");
+    bar.className = "stream-metrics";
+
+    const items = [];
+    const ttft = m.time_to_first_content ?? clientTtft;
+    if (ttft != null) items.push(["TTFT", ttft.toFixed(1) + "s"]);
+    if (m.time_to_first_reasoning != null) items.push(["Thinking", m.time_to_first_reasoning.toFixed(1) + "s"]);
+    if (m.total_time != null) items.push(["Total", m.total_time.toFixed(1) + "s"]);
+    if (m.usage && m.usage.total_tokens != null) items.push(["Tokens", m.usage.total_tokens.toLocaleString()]);
+    if (m.model_calls != null) items.push(["Model calls", m.model_calls]);
+    if (m.tool_calls != null) items.push(["Tool calls", m.tool_calls]);
+    if (m.inter_token_latencies && m.inter_token_latencies.length > 0) {
+      const sum = m.inter_token_latencies.reduce(function (a, b) { return a + b; }, 0);
+      const avg = sum / m.inter_token_latencies.length;
+      items.push(["Avg ITL", (avg * 1000).toFixed(0) + "ms"]);
+    }
+
+    for (var i = 0; i < items.length; i++) {
+      var span = document.createElement("span");
+      span.className = "metric";
+      span.innerHTML = '<span class="metric-label">' + items[i][0] + '</span>'
+        + '<span class="metric-value">' + items[i][1] + '</span>';
+      bar.appendChild(span);
+    }
+
+    assistantEl.appendChild(bar);
+  }
+
+  function pushRawChunk(chunk) {
+    rawChunks.push(chunk);
   }
 
   return {
@@ -363,8 +691,33 @@ function createStreamRenderer(assistantEl) {
       // announcement we can safely ignore.
     },
     finalize,
+    setMetrics,
     getResponseText: () => responseText,
+    pushRawChunk,
+    getRawChunks: () => rawChunks,
   };
+}
+
+function showRawResponse(chunks) {
+  let modal = document.getElementById("raw-response-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "raw-response-modal";
+    modal.className = "raw-modal";
+    modal.innerHTML = '<div class="raw-modal-content">' +
+      '<div class="raw-modal-header"><h3>Raw API Response</h3><button class="raw-modal-close">&times;</button></div>' +
+      '<pre class="raw-modal-body"></pre></div>';
+    document.body.appendChild(modal);
+    modal.querySelector(".raw-modal-close").addEventListener("click", function () {
+      modal.classList.remove("open");
+    });
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) modal.classList.remove("open");
+    });
+  }
+  const body = modal.querySelector(".raw-modal-body");
+  body.textContent = JSON.stringify(chunks, null, 2);
+  modal.classList.add("open");
 }
 
 async function sendMessage() {
@@ -383,17 +736,28 @@ async function sendMessage() {
   scrollToBottom();
 
   const renderer = createStreamRenderer(assistantEl);
+  const requestStart = performance.now();
+  let clientTtft = null;
 
   setStreaming(true);
 
   try {
+    const reqBody = { messages: messages, stream: true };
+    if (userTemperature !== null) reqBody.temperature = userTemperature;
+    if (userMaxTokens !== null) reqBody.max_tokens = userMaxTokens;
+    if (userTopP !== null) reqBody.top_p = userTopP;
+    if (userTopK !== null) reqBody.top_k = userTopK;
+    if (userFreqPenalty !== null) reqBody.frequency_penalty = userFreqPenalty;
+    if (userPresencePenalty !== null) reqBody.presence_penalty = userPresencePenalty;
+    if (userRepPenalty !== null) reqBody.repetition_penalty = userRepPenalty;
+    if (userReasoningEffort !== null) reqBody.reasoning_effort = userReasoningEffort;
+    if (userApiBase !== null) reqBody.api_base = userApiBase;
+    if (userResponsesApi) reqBody.use_responses_api = true;
+
     const resp = await fetch("/v1/chat/completions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        messages: messages,
-        stream: true,
-      }),
+      body: JSON.stringify(reqBody),
     });
 
     if (!resp.ok) {
@@ -429,14 +793,26 @@ async function sendMessage() {
           continue; // skip malformed
         }
 
+        renderer.pushRawChunk(parsed);
+
         // Surface backend errors that arrive mid-stream.
         if (parsed.error) {
           appendError("Stream error: " + (parsed.error.message || "unknown"));
           continue;
         }
 
+        // Detect metrics chunk (empty choices array + stream_metrics).
+        if (parsed.stream_metrics) {
+          renderer.setMetrics(parsed.stream_metrics, parsed.usage);
+          continue;
+        }
+
         const delta = parsed.choices?.[0]?.delta;
         if (delta) {
+          // Record client-side TTFT on first content delta.
+          if (delta.content && clientTtft === null) {
+            clientTtft = (performance.now() - requestStart) / 1000;
+          }
           renderer.handleDelta(delta);
         }
       }
@@ -450,7 +826,7 @@ async function sendMessage() {
     }
   }
 
-  renderer.finalize();
+  renderer.finalize(clientTtft);
   const finalText = renderer.getResponseText();
   if (finalText) {
     messages.push({ role: "assistant", content: finalText });

--- a/static/index.html
+++ b/static/index.html
@@ -5,11 +5,104 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ui-template</title>
   <link rel="stylesheet" href="style.css">
+  <!-- KaTeX for math rendering (optional -- remove these two lines if not needed) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js"></script>
 </head>
 <body>
   <header>
-    <h1>ui-template</h1>
+    <div class="header-row">
+      <div>
+        <h1>ui-template</h1>
+        <span id="model-name" class="model-subtitle"></span>
+      </div>
+      <button id="settings-btn" title="Settings &amp; Info" aria-label="Settings">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="3"></circle>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+        </svg>
+      </button>
+    </div>
   </header>
+  <aside id="settings-panel" class="settings-panel">
+    <div class="settings-header">
+      <h2>Settings & Info</h2>
+      <button id="settings-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="settings-body">
+      <section class="settings-section">
+        <h3>Model</h3>
+        <div id="model-info" class="model-info"></div>
+      </section>
+      <section class="settings-section">
+        <h3>Backend</h3>
+        <div class="param-group">
+          <label for="param-backend">Inference Path</label>
+          <select id="param-backend">
+            <option value="direct">Direct (vLLM)</option>
+            <option value="llamastack">LlamaStack</option>
+          </select>
+        </div>
+        <div class="param-group" id="responses-api-group" style="display:none">
+          <label>
+            <input type="checkbox" id="param-responses-api">
+            Responses API
+            <span class="param-hint">(requires LlamaStack backend)</span>
+          </label>
+        </div>
+      </section>
+      <section class="settings-section">
+        <h3>Parameters</h3>
+        <div class="param-group">
+          <label for="param-temperature">Temperature <span id="temp-value">0.3</span></label>
+          <input type="range" id="param-temperature" min="0" max="2" step="0.1" value="0.3">
+        </div>
+        <div class="param-group">
+          <label for="param-max-tokens">Max Tokens</label>
+          <input type="number" id="param-max-tokens" min="256" max="16384" step="256" value="4096">
+        </div>
+        <div class="param-group">
+          <label for="param-top-p">Top P <span id="top-p-value"></span></label>
+          <input type="range" id="param-top-p" min="0" max="1" step="0.05" value="">
+        </div>
+        <div class="param-group">
+          <label for="param-top-k">Top K (0 = disabled)</label>
+          <input type="number" id="param-top-k" min="0" max="200" step="1" value="">
+        </div>
+        <div class="param-group">
+          <label for="param-freq-penalty">Frequency Penalty <span id="freq-penalty-value"></span></label>
+          <input type="range" id="param-freq-penalty" min="-2" max="2" step="0.1" value="0">
+        </div>
+        <div class="param-group">
+          <label for="param-presence-penalty">Presence Penalty <span id="presence-penalty-value"></span></label>
+          <input type="range" id="param-presence-penalty" min="-2" max="2" step="0.1" value="0">
+        </div>
+        <div class="param-group">
+          <label for="param-rep-penalty">Repetition Penalty <span id="rep-penalty-value"></span></label>
+          <input type="range" id="param-rep-penalty" min="0.5" max="2" step="0.05" value="1">
+        </div>
+        <div class="param-group">
+          <label for="param-reasoning">Reasoning Effort</label>
+          <select id="param-reasoning">
+            <option value="">Default</option>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+      </section>
+      <section class="settings-section">
+        <h3>System Prompt</h3>
+        <pre id="system-prompt" class="system-prompt-display"></pre>
+      </section>
+      <section class="settings-section">
+        <h3>Tools <span id="tools-count"></span></h3>
+        <div id="tools-list" class="tools-list"></div>
+      </section>
+    </div>
+  </aside>
+  <div id="settings-overlay" class="settings-overlay"></div>
   <main id="chat">
     <div id="messages"></div>
   </main>

--- a/static/style.css
+++ b/static/style.css
@@ -45,8 +45,7 @@ header {
 header h1 {
   font-size: 16px;
   font-weight: 600;
-  max-width: var(--max-width);
-  margin: 0 auto;
+  margin: 0;
 }
 
 main {
@@ -253,7 +252,7 @@ footer {
 
 /* -- Rich streaming phases ------------------------------------------------- */
 
-/* Thinking panel — collapsed by default, shown as a quiet meta block above
+/* Thinking panel -- collapsed by default, shown as a quiet meta block above
    the response content. Pulses while reasoning_content is still streaming. */
 .thinking-panel {
   margin-bottom: 10px;
@@ -276,7 +275,7 @@ footer {
 }
 
 .thinking-panel summary::before {
-  content: "▸";
+  content: "\25B8";
   display: inline-block;
   transition: transform 0.15s;
   font-size: 11px;
@@ -307,11 +306,9 @@ footer {
   white-space: pre-wrap;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   line-height: 1.5;
-  max-height: 300px;
-  overflow-y: auto;
 }
 
-/* Tool calls — discrete pills showing the agent's tool execution. */
+/* Tool calls -- discrete pills showing the agent's tool execution. */
 .tool-calls {
   display: flex;
   flex-direction: column;
@@ -347,6 +344,24 @@ footer {
   align-items: center;
   gap: 8px;
   font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.tool-header::marker,
+.tool-header::-webkit-details-marker {
+  display: none;
+}
+
+.tool-header::before {
+  content: "\25B8";
+  font-size: 11px;
+  transition: transform 0.15s;
+}
+
+.tool-call[open] .tool-header::before {
+  transform: rotate(90deg);
 }
 
 .tool-icon {
@@ -411,18 +426,33 @@ footer {
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 200px;
-  overflow-y: auto;
 }
 
 .tool-call.error .tool-result {
   color: #b91c1c;
 }
 
-/* Response content — the user-visible final answer. The streaming
+/* Response content -- the user-visible final answer. The streaming
    indicator (cursor) is a separate element that lives next to it. */
 .response-content {
   white-space: normal;
+}
+
+/* KaTeX math -- rendered inline by katex.renderToString(). Shield from
+   the parent message's word-wrap: break-word which would break layout. */
+.katex-display-block {
+  display: block;
+  margin: 12px 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-align: center;
+}
+
+.response-content .katex {
+  font-size: 1.1em;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: nowrap;
 }
 
 .response-content:empty + .streaming-indicator {
@@ -443,4 +473,355 @@ footer {
 
 @keyframes blink {
   50% { opacity: 0; }
+}
+
+/* -- Stream metrics bar ---------------------------------------------------- */
+.stream-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.02);
+  border-top: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1.6;
+}
+
+.stream-metrics .metric {
+  white-space: nowrap;
+}
+
+.stream-metrics .metric-label {
+  font-weight: 400;
+}
+
+.stream-metrics .metric-value {
+  font-weight: 600;
+  margin-left: 3px;
+}
+
+/* -- Settings panel --------------------------------------------------------- */
+
+.header-row {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.model-subtitle {
+  font-size: 12px;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+#settings-btn {
+  background: none;
+  border: none;
+  color: var(--color-header-text);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+#settings-btn:hover {
+  opacity: 1;
+}
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 99;
+}
+
+.settings-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.settings-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 380px;
+  max-width: 90vw;
+  height: 100vh;
+  background: var(--color-bg);
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+  transform: translateX(100%);
+  transition: transform 0.25s ease;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.settings-panel.open {
+  transform: translateX(0);
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.settings-header h2 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.settings-header button {
+  background: none;
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  padding: 2px 6px;
+  line-height: 1;
+}
+
+.settings-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 18px;
+}
+
+.settings-section {
+  margin-bottom: 20px;
+}
+
+.settings-section h3 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-dim);
+  margin-bottom: 8px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  font-size: 14px;
+}
+
+.info-label {
+  color: var(--color-text-dim);
+}
+
+.info-value {
+  font-weight: 500;
+}
+
+.param-group {
+  margin-bottom: 12px;
+}
+
+.param-group label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.param-group input[type="range"] {
+  width: 100%;
+  accent-color: var(--color-accent);
+}
+
+.param-group input[type="number"] {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.system-prompt-display {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 10px;
+  white-space: pre-wrap;
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.tool-info {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+
+.tool-info summary {
+  padding: 8px 10px;
+  cursor: pointer;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tool-info summary::before {
+  content: "\25B8";
+  font-size: 11px;
+  transition: transform 0.15s;
+}
+
+.tool-info[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.tool-info summary::marker,
+.tool-info summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-description {
+  padding: 0 10px 8px;
+  color: var(--color-text-dim);
+  line-height: 1.5;
+}
+
+.tool-params {
+  padding: 0 10px 8px;
+  font-size: 12px;
+  color: var(--color-text-dim);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* -- Additional parameter controls ----------------------------------------- */
+
+.param-group select {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 14px;
+  background: white;
+}
+
+/* -- Raw API response button ----------------------------------------------- */
+
+.raw-response-btn {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 2px 8px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: var(--color-text-dim);
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.raw-response-btn:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--color-text);
+}
+
+/* -- Raw response modal ---------------------------------------------------- */
+
+.raw-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.raw-modal.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.raw-modal-content {
+  background: var(--color-bg);
+  border-radius: 10px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+  width: 90vw;
+  max-width: 800px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.raw-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.raw-modal-header h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.raw-modal-close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.raw-modal-body {
+  flex: 1;
+  overflow: auto;
+  padding: 12px 16px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+.param-hint {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.param-group label input[type="checkbox"] {
+  margin-right: 6px;
+  vertical-align: middle;
 }


### PR DESCRIPTION
## Summary

Upstream the seven UI features developed and validated in the calculus-ui project so all future projects scaffolded from `ui-template` get them out of the box.

- **Settings panel** -- slide-out sidebar with model info, system prompt display, registered tools list, and adjustable inference parameters (temperature, top-p, top-k, frequency/presence/repetition penalties, reasoning effort)
- **Agent info fetch** -- loads `/v1/agent-info` on page load, populates settings panel and header subtitle with model name
- **Backend toggle** -- switch between direct vLLM and LlamaStack inference paths, with Responses API checkbox
- **Stream metrics bar** -- TTFT, total time, token count, avg inter-token latency, model calls, tool calls
- **Raw response viewer** -- per-message "View Raw Response" button opens a modal with full JSON chunks
- **Collapsible tool pills** -- tool calls use `<details>/<summary>` so args/results are collapsed by default
- **KaTeX math rendering** -- optional, guarded by `typeof katex !== "undefined"` so removing the CDN links degrades gracefully

Only static files changed (`index.html`, `app.js`, `style.css`). No Go code modifications. The sentinel string `ui-template` is preserved in `<title>` and `<h1>` for `fips-agents create ui` customization.

## Test plan

- [ ] Open `index.html` in a browser -- verify page loads without JS errors
- [ ] Click settings gear icon -- verify panel slides open with all sections
- [ ] Verify KaTeX CDN loads (check Network tab) and renders `\( x^2 \)` inline
- [ ] Remove KaTeX `<link>` and `<script>` from HTML -- verify page still works without math
- [ ] Send a message to a running agent backend -- verify stream metrics bar appears after response
- [ ] Click "View Raw Response" -- verify modal shows JSON chunks
- [ ] Trigger a tool call -- verify it renders as a collapsible `<details>` pill
- [ ] Run `fips-agents create ui my-project` -- verify "ui-template" is replaced with "my-project" in title and h1