### PR TITLE
fix: Create new tool pill for each unique call_id (#72)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -339,8 +339,11 @@ function createStreamRenderer(assistantEl) {
       if (delta.tool_calls && Array.isArray(delta.tool_calls)) {
         for (const tc of delta.tool_calls) {
           const idx = tc.index ?? 0;
-          // First delta for this index brings id+name.
-          if (tc.id && !toolCalls.has(idx)) {
+          // First delta for a new tool call brings id+name.
+          // Check by call_id, not just index — a second model
+          // iteration reuses index 0 with a different call_id.
+          const existing = toolCalls.get(idx);
+          if (tc.id && (!existing || existing.callId !== tc.id)) {
             const name = (tc.function && tc.function.name) || "tool";
             startToolCall(idx, tc.id, name);
             // Some chunks include initial args along with id+name.


### PR DESCRIPTION
## Summary

- When the agent makes sequential tool calls across model iterations (e.g. "get weather in Miami and Seattle"), both arrive at `index: 0` with different `call_id`s
- The UI checked `toolCalls.has(idx)` to gate pill creation, so the second call was treated as a continuation of the first — only one pill appeared despite two tool executions
- Fix: check by `call_id` instead of `index`, so a new `call_id` at the same index creates a new pill

Companion server-side fix: redhat-ai-americas/agent-template@5e37a1b

## Test plan

- [ ] Send a prompt that triggers two sequential tool calls (e.g. "Get weather in Miami and Seattle")
- [ ] Verify two distinct tool pills appear in the UI
- [ ] Verify metrics bar shows correct tool call count matching visible pills
- [ ] Verify single tool call still works normally
- [ ] Verify concurrent tool calls (multiple tools in one model turn) still work