### PR TITLE
feat: Inline thumbs-up/-down feedback on assistant messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A minimal chat UI that connects to any OpenAI-compatible API endpoint (vLLM, an 
 
 **Stream metrics and debugging** -- Token counts, average inter-token latency, and time-to-first-token. A raw API response viewer for inspecting the full SSE payload.
 
-**Inline feedback** -- Hover-revealed thumbs-up/-down on completed assistant messages. Thumbs-down opens a modal for category (Inaccurate / Not helpful / Harmful / Too long / Other) plus an optional comment, then POSTs to the backend's `/v1/feedback` endpoint using the trace ID surfaced in the `X-Trace-Id` response header. Controls are hidden when no `trace_id` is available, so older backends silently degrade.
+**Inline feedback** -- Thumbs-up/-down on completed assistant messages, with an inline note next to the icon after a thumbs-down submission. The note is editable: clicking it reopens the modal so you can change the category, edit the comment, or flip the rating. Edits PATCH the existing record rather than creating duplicates. Visibility is configurable via the `data-feedback-visibility` attribute on `<body>` in `index.html` -- `hover` (default), `always` (icons always visible, useful for internal/eval/QA tooling), or `off`. Controls are hidden when no `trace_id` is available, so older backends silently degrade.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A minimal chat UI that connects to any OpenAI-compatible API endpoint (vLLM, an 
 
 **Stream metrics and debugging** -- Token counts, average inter-token latency, and time-to-first-token. A raw API response viewer for inspecting the full SSE payload.
 
+**Inline feedback** -- Hover-revealed thumbs-up/-down on completed assistant messages. Thumbs-down opens a modal for category (Inaccurate / Not helpful / Harmful / Too long / Other) plus an optional comment, then POSTs to the backend's `/v1/feedback` endpoint using the trace ID surfaced in the `X-Trace-Id` response header. Controls are hidden when no `trace_id` is available, so older backends silently degrade.
+
 ## Architecture
 
 The Go server embeds the static frontend into a single binary via `go:embed`. At runtime it does three things:
@@ -29,6 +31,8 @@ The frontend discovers the backend via `/api/config` on page load, but all API t
 The backend must be OpenAI chat-completions compatible (`POST /v1/chat/completions` with SSE streaming).
 
 Optionally, the backend can serve `GET /v1/agent-info` to populate the settings panel with model info, system prompt, available tools, and backend configuration. If this endpoint is not available, the settings panel shows only the client-side controls.
+
+For inline feedback to work, the backend must surface a `trace_id` (either in an `X-Trace-Id` response header or as a top-level `trace_id` field on the final SSE usage chunk) and accept `POST /v1/feedback` with `{trace_id, rating, comment?}`. Backends without these features simply hide the feedback icons; everything else continues to work.
 
 ## Quick Start
 

--- a/static/app.js
+++ b/static/app.js
@@ -471,6 +471,7 @@ function createStreamRenderer(assistantEl) {
   let responseIndicator = null;
   let streamMetrics = null;     // server-sent metrics object
   let rawChunks = [];
+  let traceId = null;           // populated from usage chunk or response header
 
   // Per-tool state: index -> { pillEl, nameEl, statusEl, argsEl, resultEl, args, name, callId }
   const toolCalls = new Map();
@@ -651,13 +652,23 @@ function createStreamRenderer(assistantEl) {
     }
 
     assistantEl.appendChild(bar);
+
+    // Feedback controls (only when we have a trace_id to attach to)
+    if (traceId) {
+      assistantEl.appendChild(createFeedbackControls(traceId));
+    }
   }
 
   function pushRawChunk(chunk) {
     rawChunks.push(chunk);
   }
 
+  function setTraceId(id) {
+    if (id) traceId = id;
+  }
+
   return {
+    setTraceId,
     handleDelta(delta) {
       // Reasoning ("thinking") phase
       if (delta.reasoning_content) {
@@ -699,6 +710,172 @@ function createStreamRenderer(assistantEl) {
     pushRawChunk,
     getRawChunks: () => rawChunks,
   };
+}
+
+// -- Feedback controls -----------------------------------------------------
+// Hover-revealed thumbs-up/-down on completed assistant messages. Thumbs-up
+// records a positive rating immediately; thumbs-down opens a modal so the
+// user can pick a category and (optionally) leave a free-text comment.
+//
+// State per message is local: once a rating is submitted, both icons stay
+// visible but the chosen one is filled and further clicks are ignored.
+
+const FEEDBACK_CATEGORIES = [
+  "Inaccurate",
+  "Not helpful",
+  "Harmful",
+  "Too long",
+  "Other",
+];
+
+function createFeedbackControls(traceId) {
+  const wrap = document.createElement("div");
+  wrap.className = "feedback-controls";
+  wrap.dataset.state = "idle"; // idle | submitted
+
+  const upBtn = document.createElement("button");
+  upBtn.className = "feedback-btn feedback-up";
+  upBtn.title = "Good response";
+  upBtn.setAttribute("aria-label", "Thumbs up");
+  upBtn.innerHTML = thumbSvg(true);
+
+  const downBtn = document.createElement("button");
+  downBtn.className = "feedback-btn feedback-down";
+  downBtn.title = "Bad response";
+  downBtn.setAttribute("aria-label", "Thumbs down");
+  downBtn.innerHTML = thumbSvg(false);
+
+  upBtn.addEventListener("click", function () {
+    if (wrap.dataset.state === "submitted") return;
+    markSubmitted(wrap, "up");
+    submitFeedback(traceId, 1, null, null).catch(function (err) {
+      revertSubmitted(wrap);
+      appendError("Could not submit feedback: " + err.message);
+    });
+  });
+
+  downBtn.addEventListener("click", function () {
+    if (wrap.dataset.state === "submitted") return;
+    showFeedbackModal(function (category, comment) {
+      markSubmitted(wrap, "down");
+      submitFeedback(traceId, -1, category, comment).catch(function (err) {
+        revertSubmitted(wrap);
+        appendError("Could not submit feedback: " + err.message);
+      });
+    });
+  });
+
+  wrap.appendChild(upBtn);
+  wrap.appendChild(downBtn);
+  return wrap;
+}
+
+function thumbSvg(up) {
+  // Outline thumb; click handler swaps in the filled variant via CSS.
+  const transform = up ? "" : ' transform="scale(1,-1) translate(0,-24)"';
+  return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"'
+    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round"' + transform + '>'
+    + '<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3z"></path>'
+    + '<line x1="7" y1="11" x2="7" y2="22"></line>'
+    + '</svg>';
+}
+
+function markSubmitted(wrap, which) {
+  wrap.dataset.state = "submitted";
+  wrap.dataset.choice = which;
+}
+
+function revertSubmitted(wrap) {
+  wrap.dataset.state = "idle";
+  delete wrap.dataset.choice;
+}
+
+async function submitFeedback(traceId, rating, category, comment) {
+  const body = {
+    trace_id: traceId,
+    rating: rating,
+  };
+  if (category) {
+    // Backend doesn't model category as a first-class column; encode it
+    // as a bracketed prefix on comment so the category survives the round
+    // trip and remains recoverable from /v1/feedback queries.
+    body.comment = comment ? "[" + category + "] " + comment : "[" + category + "]";
+  } else if (comment) {
+    body.comment = comment;
+  }
+
+  const resp = await fetch("/v1/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(function () { return ""; });
+    throw new Error("HTTP " + resp.status + (text ? " — " + text : ""));
+  }
+  return resp.json();
+}
+
+function showFeedbackModal(onSubmit) {
+  let modal = document.getElementById("feedback-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "feedback-modal";
+    modal.className = "feedback-modal";
+    const optionsHtml = FEEDBACK_CATEGORIES.map(function (c, i) {
+      return '<label class="feedback-option">'
+        + '<input type="radio" name="feedback-category" value="' + c + '"'
+        + (i === 0 ? " checked" : "") + '> ' + c
+        + '</label>';
+    }).join("");
+    modal.innerHTML = '<div class="feedback-modal-content">'
+      + '<div class="feedback-modal-header">'
+      +   '<h3>What was wrong?</h3>'
+      +   '<button class="feedback-modal-close" aria-label="Close">&times;</button>'
+      + '</div>'
+      + '<div class="feedback-modal-body">'
+      +   '<div class="feedback-options">' + optionsHtml + '</div>'
+      +   '<textarea class="feedback-comment" placeholder="Optional details..." rows="3"></textarea>'
+      + '</div>'
+      + '<div class="feedback-modal-footer">'
+      +   '<button class="feedback-cancel">Cancel</button>'
+      +   '<button class="feedback-submit">Submit</button>'
+      + '</div>'
+      + '</div>';
+    document.body.appendChild(modal);
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) closeFeedbackModal();
+    });
+    modal.querySelector(".feedback-modal-close")
+      .addEventListener("click", closeFeedbackModal);
+    modal.querySelector(".feedback-cancel")
+      .addEventListener("click", closeFeedbackModal);
+  }
+
+  // Reset previous values on every open.
+  const radios = modal.querySelectorAll('input[name="feedback-category"]');
+  radios[0].checked = true;
+  modal.querySelector(".feedback-comment").value = "";
+
+  // Re-bind submit (closure over the new callback).
+  const submitBtn = modal.querySelector(".feedback-submit");
+  const newSubmit = submitBtn.cloneNode(true);
+  submitBtn.parentNode.replaceChild(newSubmit, submitBtn);
+  newSubmit.addEventListener("click", function () {
+    const checked = modal.querySelector('input[name="feedback-category"]:checked');
+    const category = checked ? checked.value : null;
+    const comment = modal.querySelector(".feedback-comment").value.trim() || null;
+    closeFeedbackModal();
+    onSubmit(category, comment);
+  });
+
+  modal.classList.add("open");
+  modal.querySelector(".feedback-comment").focus();
+}
+
+function closeFeedbackModal() {
+  const modal = document.getElementById("feedback-modal");
+  if (modal) modal.classList.remove("open");
 }
 
 function showRawResponse(chunks) {
@@ -767,6 +944,12 @@ async function sendMessage() {
       throw new Error("API returned " + resp.status + ": " + resp.statusText);
     }
 
+    // Capture trace_id from the response header so feedback controls
+    // can attach to a real trace. (The same value is also echoed on
+    // the final usage chunk for transports that hide headers.)
+    const headerTraceId = resp.headers.get("X-Trace-Id");
+    if (headerTraceId) renderer.setTraceId(headerTraceId);
+
     const reader = resp.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
@@ -807,6 +990,7 @@ async function sendMessage() {
         // Detect metrics chunk (empty choices array + stream_metrics).
         if (parsed.stream_metrics) {
           renderer.setMetrics(parsed.stream_metrics, parsed.usage);
+          if (parsed.trace_id) renderer.setTraceId(parsed.trace_id);
           continue;
         }
 

--- a/static/app.js
+++ b/static/app.js
@@ -734,75 +734,160 @@ function createFeedbackControls(traceId) {
   wrap.dataset.state = "idle"; // idle | submitted
 
   const upBtn = document.createElement("button");
+  upBtn.type = "button";
   upBtn.className = "feedback-btn feedback-up";
   upBtn.title = "Good response";
   upBtn.setAttribute("aria-label", "Thumbs up");
-  upBtn.innerHTML = thumbSvg(true);
+  upBtn.innerHTML = THUMB_UP_SVG;
 
   const downBtn = document.createElement("button");
+  downBtn.type = "button";
   downBtn.className = "feedback-btn feedback-down";
   downBtn.title = "Bad response";
   downBtn.setAttribute("aria-label", "Thumbs down");
-  downBtn.innerHTML = thumbSvg(false);
+  downBtn.innerHTML = THUMB_DOWN_SVG;
+
+  // Inline note rendered next to the thumbs after a thumbs-down submission.
+  // Click it to re-open the modal and edit the existing record.
+  const noteEl = document.createElement("button");
+  noteEl.type = "button";
+  noteEl.className = "feedback-note";
+  noteEl.hidden = true;
+  noteEl.title = "Edit feedback";
+
+  // Per-message state. feedbackId is null until the first POST returns,
+  // then every subsequent edit PATCHes that record.
+  const state = {
+    feedbackId: null,
+    rating: null,        // 1 | -1 | null
+    category: null,
+    comment: null,
+  };
+
+  function persistChange(rating, category, comment) {
+    const previous = { ...state };
+    optimisticApply(wrap, noteEl, state, rating, category, comment);
+    sendFeedbackUpdate(traceId, state, rating, category, comment).catch(function (err) {
+      // Roll back on failure.
+      Object.assign(state, previous);
+      optimisticApply(wrap, noteEl, state, previous.rating, previous.category, previous.comment);
+      appendError("Could not save feedback: " + err.message);
+    });
+  }
 
   upBtn.addEventListener("click", function () {
-    if (wrap.dataset.state === "submitted") return;
-    markSubmitted(wrap, "up");
-    submitFeedback(traceId, 1, null, null).catch(function (err) {
-      revertSubmitted(wrap);
-      appendError("Could not submit feedback: " + err.message);
-    });
+    if (state.rating === 1) return; // already up; nothing to do
+    persistChange(1, null, null);
   });
 
   downBtn.addEventListener("click", function () {
-    if (wrap.dataset.state === "submitted") return;
-    showFeedbackModal(function (category, comment) {
-      markSubmitted(wrap, "down");
-      submitFeedback(traceId, -1, category, comment).catch(function (err) {
-        revertSubmitted(wrap);
-        appendError("Could not submit feedback: " + err.message);
-      });
+    showFeedbackModal({
+      category: state.category,
+      comment: state.comment,
+    }, function (category, comment) {
+      persistChange(-1, category, comment);
+    });
+  });
+
+  noteEl.addEventListener("click", function () {
+    showFeedbackModal({
+      category: state.category,
+      comment: state.comment,
+    }, function (category, comment) {
+      persistChange(-1, category, comment);
     });
   });
 
   wrap.appendChild(upBtn);
   wrap.appendChild(downBtn);
+  wrap.appendChild(noteEl);
   return wrap;
 }
 
-function thumbSvg(up) {
-  // Outline thumb; click handler swaps in the filled variant via CSS.
-  const transform = up ? "" : ' transform="scale(1,-1) translate(0,-24)"';
-  return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"'
-    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round"' + transform + '>'
-    + '<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3z"></path>'
-    + '<line x1="7" y1="11" x2="7" y2="22"></line>'
-    + '</svg>';
+// Update the local state object and sync the DOM in one place.
+function optimisticApply(wrap, noteEl, state, rating, category, comment) {
+  state.rating = rating;
+  state.category = category;
+  state.comment = comment;
+  if (rating === 1) {
+    wrap.dataset.state = "submitted";
+    wrap.dataset.choice = "up";
+    noteEl.hidden = true;
+    noteEl.textContent = "";
+  } else if (rating === -1) {
+    wrap.dataset.state = "submitted";
+    wrap.dataset.choice = "down";
+    noteEl.textContent = formatNote(category, comment);
+    noteEl.hidden = false;
+  } else {
+    wrap.dataset.state = "idle";
+    delete wrap.dataset.choice;
+    noteEl.hidden = true;
+    noteEl.textContent = "";
+  }
 }
+
+function formatNote(category, comment) {
+  const cat = category ? "[" + category + "]" : "";
+  const txt = comment ? " " + comment : "";
+  return (cat + txt).trim() || "(no details)";
+}
+
+// First call POSTs and stores the new feedback_id; later calls PATCH.
+async function sendFeedbackUpdate(traceId, state, rating, category, comment) {
+  if (state.feedbackId) {
+    const updated = await patchFeedback(state.feedbackId, rating, category, comment);
+    return updated;
+  }
+  const created = await submitFeedback(traceId, rating, category, comment);
+  state.feedbackId = created.feedback_id;
+  return created;
+}
+
+// Hand-aligned 16×16 paths, in the same outline style as the rest of
+// the UI's icons. Filled state is applied via CSS (`fill: currentColor`)
+// so the same path serves both states.
+const THUMB_UP_SVG =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"'
+  + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+  + '<path d="M7 10v12"></path>'
+  + '<path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l4.06-9a1.93 1.93 0 0 1 1.78 1.04 5.93 5.93 0 0 1 .98 4.5z"></path>'
+  + '</svg>';
+
+const THUMB_DOWN_SVG =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"'
+  + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+  + '<path d="M17 14V2"></path>'
+  + '<path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-4.06 9a1.93 1.93 0 0 1-1.78-1.04 5.93 5.93 0 0 1-.98-4.5z"></path>'
+  + '</svg>';
 
 function markSubmitted(wrap, which) {
   wrap.dataset.state = "submitted";
   wrap.dataset.choice = which;
 }
 
-function revertSubmitted(wrap) {
-  wrap.dataset.state = "idle";
-  delete wrap.dataset.choice;
+function restorePrevious(wrap, previous) {
+  if (previous) {
+    wrap.dataset.state = "submitted";
+    wrap.dataset.choice = previous;
+  } else {
+    wrap.dataset.state = "idle";
+    delete wrap.dataset.choice;
+  }
+}
+
+// Encode the optional UI category as a bracketed prefix on `comment` so
+// the backend's existing schema captures it without a first-class column.
+function encodeComment(category, comment) {
+  if (category && comment) return "[" + category + "] " + comment;
+  if (category) return "[" + category + "]";
+  return comment || null;
 }
 
 async function submitFeedback(traceId, rating, category, comment) {
-  const body = {
-    trace_id: traceId,
-    rating: rating,
-  };
-  if (category) {
-    // Backend doesn't model category as a first-class column; encode it
-    // as a bracketed prefix on comment so the category survives the round
-    // trip and remains recoverable from /v1/feedback queries.
-    body.comment = comment ? "[" + category + "] " + comment : "[" + category + "]";
-  } else if (comment) {
-    body.comment = comment;
-  }
+  const body = { trace_id: traceId, rating: rating };
+  const c = encodeComment(category, comment);
+  if (c !== null) body.comment = c;
 
   const resp = await fetch("/v1/feedback", {
     method: "POST",
@@ -816,16 +901,45 @@ async function submitFeedback(traceId, rating, category, comment) {
   return resp.json();
 }
 
-function showFeedbackModal(onSubmit) {
+// PATCH an existing record. The backend treats `null` fields as
+// "leave unchanged"; we always send rating + comment because the user
+// may flip either or both in a single edit.
+async function patchFeedback(feedbackId, rating, category, comment) {
+  const body = {
+    rating: rating,
+    // Send "" rather than null when there's no comment so the field
+    // gets explicitly cleared on the backend (e.g. flipping from down
+    // back to up — though our UI currently doesn't expose that flow).
+    comment: encodeComment(category, comment) || "",
+  };
+  const resp = await fetch("/v1/feedback/" + encodeURIComponent(feedbackId), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(function () { return ""; });
+    throw new Error("HTTP " + resp.status + (text ? " — " + text : ""));
+  }
+  return resp.json();
+}
+
+function showFeedbackModal(prefill, onSubmit) {
+  // Backwards-compat: allow `showFeedbackModal(onSubmit)` calls.
+  if (typeof prefill === "function") {
+    onSubmit = prefill;
+    prefill = {};
+  }
+  prefill = prefill || {};
+
   let modal = document.getElementById("feedback-modal");
   if (!modal) {
     modal = document.createElement("div");
     modal.id = "feedback-modal";
     modal.className = "feedback-modal";
-    const optionsHtml = FEEDBACK_CATEGORIES.map(function (c, i) {
+    const optionsHtml = FEEDBACK_CATEGORIES.map(function (c) {
       return '<label class="feedback-option">'
-        + '<input type="radio" name="feedback-category" value="' + c + '"'
-        + (i === 0 ? " checked" : "") + '> ' + c
+        + '<input type="radio" name="feedback-category" value="' + c + '"> ' + c
         + '</label>';
     }).join("");
     modal.innerHTML = '<div class="feedback-modal-content">'
@@ -852,10 +966,20 @@ function showFeedbackModal(onSubmit) {
       .addEventListener("click", closeFeedbackModal);
   }
 
-  // Reset previous values on every open.
+  // Pre-populate with the caller's last submission (or defaults).
   const radios = modal.querySelectorAll('input[name="feedback-category"]');
-  radios[0].checked = true;
-  modal.querySelector(".feedback-comment").value = "";
+  const wantCategory = prefill.category || FEEDBACK_CATEGORIES[0];
+  let matched = false;
+  radios.forEach(function (r) {
+    if (r.value === wantCategory) {
+      r.checked = true;
+      matched = true;
+    } else {
+      r.checked = false;
+    }
+  });
+  if (!matched && radios.length) radios[0].checked = true;
+  modal.querySelector(".feedback-comment").value = prefill.comment || "";
 
   // Re-bind submit (closure over the new callback).
   const submitBtn = modal.querySelector(".feedback-submit");

--- a/static/index.html
+++ b/static/index.html
@@ -9,7 +9,19 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js"></script>
 </head>
-<body>
+<!--
+  data-feedback-visibility controls when the thumbs-up/down icons appear on
+  assistant messages.  Build-time config — change the attribute below before
+  rebuilding the binary.
+
+    hover    icons fade in on message hover (default; consumer-style polish)
+    always   icons always visible at low opacity, full opacity on hover
+             (good for internal/eval/QA tools where the affordance should be
+             obvious)
+    off      hide the icons entirely (turn the feature off without rebuilding
+             the agent or removing the gateway routes)
+-->
+<body data-feedback-visibility="hover">
   <header>
     <div class="header-row">
       <div>

--- a/static/style.css
+++ b/static/style.css
@@ -825,53 +825,113 @@ footer {
 
 .feedback-controls {
   display: flex;
-  gap: 6px;
-  margin-top: 6px;
-  opacity: 0;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
   transition: opacity 0.15s;
 }
 
-.message.assistant:hover .feedback-controls,
-.feedback-controls[data-state="submitted"] {
+/* Visibility is controlled by a body[data-feedback-visibility] attribute set
+   in index.html.  Three modes:
+     hover  — fade in on message hover (default)
+     always — always visible, slightly muted until hovered
+     off    — feature hidden entirely
+*/
+
+body[data-feedback-visibility="hover"] .feedback-controls {
+  opacity: 0;
+}
+body[data-feedback-visibility="hover"] .message.assistant:hover .feedback-controls,
+body[data-feedback-visibility="hover"] .feedback-controls[data-state="submitted"] {
   opacity: 1;
+}
+
+body[data-feedback-visibility="always"] .feedback-controls {
+  opacity: 0.55;
+}
+body[data-feedback-visibility="always"] .message.assistant:hover .feedback-controls,
+body[data-feedback-visibility="always"] .feedback-controls[data-state="submitted"] {
+  opacity: 1;
+}
+
+body[data-feedback-visibility="off"] .feedback-controls {
+  display: none;
 }
 
 .feedback-btn {
   background: none;
   border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 3px 5px;
+  border-radius: 6px;
+  padding: 4px;
+  width: 28px;
+  height: 28px;
   cursor: pointer;
   color: var(--color-text-dim);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  flex: 0 0 auto;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.feedback-btn svg {
+  display: block;
+  width: 16px;
+  height: 16px;
 }
 
 .feedback-btn:hover {
   color: var(--color-text);
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.06);
 }
 
-.feedback-controls[data-state="submitted"] .feedback-btn {
-  cursor: default;
-}
-
+/* Filled state: matching color background and a coloured stroke + fill so
+   the rated icon is unambiguous. The other icon stays selectable in
+   muted form so the user can flip the rating with a single click. */
 .feedback-controls[data-choice="up"] .feedback-up {
-  color: #16a34a;
+  color: #15803d;
+  background: rgba(22, 163, 74, 0.12);
+  border-color: rgba(22, 163, 74, 0.35);
 }
-
 .feedback-controls[data-choice="up"] .feedback-up svg {
   fill: currentColor;
 }
 
 .feedback-controls[data-choice="down"] .feedback-down {
-  color: #dc2626;
+  color: #b91c1c;
+  background: rgba(220, 38, 38, 0.12);
+  border-color: rgba(220, 38, 38, 0.35);
 }
-
 .feedback-controls[data-choice="down"] .feedback-down svg {
   fill: currentColor;
+}
+
+/* Inline note — shown next to thumbs-down after a negative rating is
+   submitted.  Click to reopen the modal and edit the existing record. */
+.feedback-note {
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--color-text);
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 3px 8px;
+  margin-left: 4px;
+  cursor: pointer;
+  max-width: 360px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.feedback-note:hover {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: var(--color-text-dim);
 }
 
 /* -- Feedback modal -------------------------------------------------------- */

--- a/static/style.css
+++ b/static/style.css
@@ -821,6 +821,178 @@ footer {
   margin-left: 4px;
 }
 
+/* -- Feedback controls ----------------------------------------------------- */
+
+.feedback-controls {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.message.assistant:hover .feedback-controls,
+.feedback-controls[data-state="submitted"] {
+  opacity: 1;
+}
+
+.feedback-btn {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 3px 5px;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.feedback-btn:hover {
+  color: var(--color-text);
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.feedback-controls[data-state="submitted"] .feedback-btn {
+  cursor: default;
+}
+
+.feedback-controls[data-choice="up"] .feedback-up {
+  color: #16a34a;
+}
+
+.feedback-controls[data-choice="up"] .feedback-up svg {
+  fill: currentColor;
+}
+
+.feedback-controls[data-choice="down"] .feedback-down {
+  color: #dc2626;
+}
+
+.feedback-controls[data-choice="down"] .feedback-down svg {
+  fill: currentColor;
+}
+
+/* -- Feedback modal -------------------------------------------------------- */
+
+.feedback-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.feedback-modal.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.feedback-modal-content {
+  background: var(--color-bg);
+  border-radius: 10px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+  width: 90vw;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.feedback-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.feedback-modal-header h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.feedback-modal-close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.feedback-modal-body {
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.feedback-options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.feedback-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.feedback-comment {
+  width: 100%;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  resize: vertical;
+}
+
+.feedback-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+.feedback-cancel,
+.feedback-submit {
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+}
+
+.feedback-cancel {
+  background: transparent;
+  color: var(--color-text);
+}
+
+.feedback-submit {
+  background: var(--color-accent);
+  color: var(--color-header-text);
+  border-color: var(--color-accent);
+}
+
+.feedback-submit:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
 .param-group label input[type="checkbox"] {
   margin-right: 6px;
   vertical-align: middle;


### PR DESCRIPTION
## Summary

Adds inline thumbs-up/-down controls to completed assistant messages following the industry-standard pattern (ChatGPT/Claude.ai-style). Icons are hover-revealed; thumbs-down opens a small modal for category + optional comment.

- **Trace ID capture**: prefers the `X-Trace-Id` response header (sync + streaming) and falls back to the top-level `trace_id` on the final SSE usage chunk. Both are introduced by fips-agents/agent-template#110.
- **Modal categories**: Inaccurate / Not helpful / Harmful / Too long / Other, plus an optional comment field. The category is encoded as a bracketed prefix on `comment` so the backend's existing schema isn't touched.
- **Optimistic UI**: icon flips immediately; on API failure the choice is reverted and an inline error message is shown.
- **Graceful degradation**: when no `trace_id` is surfaced (older backend) the icons simply stay hidden.

Closes #15. Pairs with fips-agents/agent-template#110 (trace_id surfacing) and fips-agents/gateway-template#20 (gateway routing).

## Test plan

- [x] `go test ./...` passes (no Go-side changes; reverse proxy already forwards `/v1/*`)
- [x] `node --check static/app.js` passes
- [ ] **Live browser test deferred** — no browser-test framework in this repo. Verifying end-to-end requires a running agent backend on the trace_id branch (#110) plus the gateway feedback PR (#20). Reviewer may want to spin those up before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)