### PR TITLE
feat: File upload with drag, paste, and progress chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,14 @@ The project has two layers:
 |----------|---------|-------------|
 | `API_URL` | `http://localhost:8080` | OpenAI-compatible API endpoint |
 | `PORT` | `3000` | Server listen port |
+| `UI_MAX_FILE_BYTES` | `26214400` (25 MiB) | Pre-flight client-side size cap surfaced via `/api/config`. Plain bytes or `k`/`m`/`g` (binary) suffix. The gateway is the authoritative cap; this is only used to fail fast in the browser. |
+| `UI_ALLOWED_MIME` | -- | Optional comma-separated client-side MIME allowlist surfaced via `/api/config`. Empty defers entirely to the gateway. |
+
+## File uploads
+
+The chat input supports drag-and-drop, paste, and a file-picker button. Each attached file is `POST`'d to `/v1/files` (proxied through the UI server to the gateway, which streams it to the agent), and the resulting `file_id` is included in the `file_ids` array on the next `POST /v1/chat/completions`. Uploads use `XMLHttpRequest` so the chip shows real upload progress.
+
+Pre-flight client-side validation against `UI_MAX_FILE_BYTES` and `UI_ALLOWED_MIME` is best-effort — the gateway re-validates and returns 413 / 415 / 422 (virus scan) on its own, and those errors surface on the chip too. The send button is disabled while any chip is still uploading; failed chips don't block sending (they're effectively no-ops since they have no `file_id`).
 
 ## Deployment to OpenShift
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A minimal chat UI that connects to any OpenAI-compatible API endpoint (vLLM, an 
 
 **Inline feedback** -- Thumbs-up/-down on completed assistant messages, with an inline note next to the icon after a thumbs-down submission. The note is editable: clicking it reopens the modal so you can change the category, edit the comment, or flip the rating. Edits PATCH the existing record rather than creating duplicates. Visibility is configurable via the `data-feedback-visibility` attribute on `<body>` in `index.html` -- `hover` (default), `always` (icons always visible, useful for internal/eval/QA tooling), or `off`. Controls are hidden when no `trace_id` is available, so older backends silently degrade.
 
+**File uploads** -- Drag, paste, or click to attach files. Each attachment uploads to `/v1/files` via the proxy with a determinate progress bar; the resulting `file_id` rides along on the next chat completion via `file_ids`. Pre-flight size and MIME validation runs in the browser (configurable via `UI_MAX_FILE_BYTES` / `UI_ALLOWED_MIME`); the gateway is the authoritative gate and surfaces 413 / 415 / 422 directly on the chip when its checks fail.
+
 ## Architecture
 
 The Go server embeds the static frontend into a single binary via `go:embed`. At runtime it does three things:
@@ -55,6 +57,8 @@ Set these environment variables:
 |----------|---------|-------------|
 | `API_URL` | `http://localhost:8080` | OpenAI-compatible chat completions endpoint |
 | `PORT` | `3000` | Server listen port |
+| `UI_MAX_FILE_BYTES` | `26214400` (25 MiB) | Pre-flight client-side size cap. Plain bytes or `k`/`m`/`g` (binary) suffix. The gateway is the authoritative cap. |
+| `UI_ALLOWED_MIME` | -- | Optional comma-separated client-side MIME allowlist (eg `application/pdf,image/*`). Empty defers to the gateway. |
 
 The frontend discovers the API endpoint at runtime via `GET /api/config`, so the same binary works against any backend without rebuilding.
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -6,3 +6,11 @@ metadata:
     {{- include "ui-template.labels" . | nindent 4 }}
 data:
   API_URL: {{ .Values.config.API_URL | quote }}
+  {{- with .Values.files }}
+  {{- if .maxBytes }}
+  UI_MAX_FILE_BYTES: {{ .maxBytes | quote }}
+  {{- end }}
+  {{- if .allowedMime }}
+  UI_ALLOWED_MIME: {{ .allowedMime | quote }}
+  {{- end }}
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,6 +16,20 @@ resources:
 config:
   API_URL: http://my-agent:8080
 
+# -- File upload (ui-template#16) -------------------------------------------
+# Client-side file-upload knobs. The UI uses these only to fail fast on
+# obviously oversized or wrong-typed files; the gateway (and ultimately
+# the agent) is the authoritative gate. Match the values to your
+# gateway-template chart's `files` block to avoid surprising the user
+# with a 413 they could have caught client-side.
+files:
+  # Pre-flight client-side size cap. Plain bytes or k/m/g (binary). Empty
+  # falls back to the UI server's default (25 MiB).
+  maxBytes: ""
+  # Comma-separated client-side MIME allowlist. Empty defers entirely to
+  # the gateway's allowlist, which is usually what you want.
+  allowedMime: ""
+
 service:
   port: 3000
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,17 +3,26 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/fips-agents/ui-template/static"
 )
+
+// defaultMaxFileBytes mirrors the gateway's GATEWAY_FILES_MAX_BYTES
+// default (25 MiB). The UI uses this to short-circuit obviously
+// oversized files before the network sees them, but the gateway is the
+// authoritative cap.
+const defaultMaxFileBytes int64 = 25 * 1024 * 1024
 
 func main() {
 	port := os.Getenv("PORT")
@@ -27,10 +36,35 @@ func main() {
 		slog.Warn("API_URL not set, using default", "url", apiURL)
 	}
 
+	maxFileBytes, err := parseBytes(os.Getenv("UI_MAX_FILE_BYTES"), defaultMaxFileBytes)
+	if err != nil {
+		slog.Error("invalid UI_MAX_FILE_BYTES", "error", err)
+		os.Exit(1)
+	}
+	allowedMime := strings.TrimSpace(os.Getenv("UI_ALLOWED_MIME"))
+
 	backendURL, err := url.Parse(apiURL)
 	if err != nil {
 		slog.Error("invalid API_URL", "url", apiURL, "error", err)
 		os.Exit(1)
+	}
+
+	configPayload := map[string]any{
+		"apiUrl":       apiURL,
+		"maxFileBytes": maxFileBytes,
+	}
+	if allowedMime != "" {
+		// Comma-separated list, normalised so the JS can compare
+		// case-insensitively without re-parsing.
+		var list []string
+		for _, raw := range strings.Split(allowedMime, ",") {
+			if v := strings.TrimSpace(strings.ToLower(raw)); v != "" {
+				list = append(list, v)
+			}
+		}
+		if len(list) > 0 {
+			configPayload["allowedMime"] = list
+		}
 	}
 
 	proxy := &httputil.ReverseProxy{
@@ -49,7 +83,7 @@ func main() {
 
 	mux.HandleFunc("GET /api/config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"apiUrl": apiURL})
+		_ = json.NewEncoder(w).Encode(configPayload)
 	})
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +105,12 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		slog.Info("starting server", "port", port, "api_url", apiURL)
+		slog.Info("starting server",
+			"port", port,
+			"api_url", apiURL,
+			"max_file_bytes", maxFileBytes,
+			"allowed_mime", allowedMime,
+		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server failed", "error", err)
 			os.Exit(1)
@@ -89,4 +128,37 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("server stopped")
+}
+
+// parseBytes parses a byte-count string with optional k/m/g (binary)
+// suffix. Empty string returns the fallback. Mirrors gateway-template's
+// envBytesDefault so deployments can use the same value verbatim.
+func parseBytes(raw string, fallback int64) (int64, error) {
+	s := strings.TrimSpace(strings.ToLower(raw))
+	if s == "" {
+		return fallback, nil
+	}
+	mult := int64(1)
+	for _, suf := range []struct {
+		s string
+		m int64
+	}{
+		{"gib", 1 << 30}, {"gb", 1 << 30}, {"g", 1 << 30},
+		{"mib", 1 << 20}, {"mb", 1 << 20}, {"m", 1 << 20},
+		{"kib", 1 << 10}, {"kb", 1 << 10}, {"k", 1 << 10},
+	} {
+		if strings.HasSuffix(s, suf.s) {
+			mult = suf.m
+			s = strings.TrimSuffix(s, suf.s)
+			break
+		}
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid byte count %q: %w", raw, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("byte count must be positive, got %q", raw)
+	}
+	return n * mult, nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -17,6 +17,12 @@ import (
 // buildMux creates the same ServeMux as main(), wired to the given backend URL
 // and apiURL config string.
 func buildMux(backendURL *url.URL, apiURL string) *http.ServeMux {
+	return buildMuxWithFiles(backendURL, apiURL, defaultMaxFileBytes, "")
+}
+
+// buildMuxWithFiles is the variant used by tests that exercise the
+// /api/config file-upload knobs.
+func buildMuxWithFiles(backendURL *url.URL, apiURL string, maxFileBytes int64, allowedMime string) *http.ServeMux {
 	proxy := &httputil.ReverseProxy{
 		Director: func(r *http.Request) {
 			r.URL.Scheme = backendURL.Scheme
@@ -26,13 +32,29 @@ func buildMux(backendURL *url.URL, apiURL string) *http.ServeMux {
 		FlushInterval: -1,
 	}
 
+	configPayload := map[string]any{
+		"apiUrl":       apiURL,
+		"maxFileBytes": maxFileBytes,
+	}
+	if allowedMime != "" {
+		var list []string
+		for _, raw := range strings.Split(allowedMime, ",") {
+			if v := strings.TrimSpace(strings.ToLower(raw)); v != "" {
+				list = append(list, v)
+			}
+		}
+		if len(list) > 0 {
+			configPayload["allowedMime"] = list
+		}
+	}
+
 	mux := http.NewServeMux()
 
 	mux.Handle("/v1/", proxy)
 
 	mux.HandleFunc("GET /api/config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"apiUrl": apiURL})
+		_ = json.NewEncoder(w).Encode(configPayload)
 	})
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -163,12 +185,86 @@ func TestAPIConfig(t *testing.T) {
 		t.Errorf("GET /api/config status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	var result map[string]string
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("GET /api/config decode JSON: %v", err)
 	}
 	if result["apiUrl"] != wantURL {
 		t.Errorf("GET /api/config apiUrl = %q, want %q", result["apiUrl"], wantURL)
+	}
+	// JSON numbers decode as float64. The default cap is 25 MiB.
+	if got, want := result["maxFileBytes"].(float64), float64(defaultMaxFileBytes); got != want {
+		t.Errorf("maxFileBytes = %v, want %v", got, want)
+	}
+	if _, ok := result["allowedMime"]; ok {
+		t.Errorf("allowedMime should be omitted by default, got %v", result["allowedMime"])
+	}
+}
+
+func TestAPIConfig_FileUploadOverrides(t *testing.T) {
+	backendURL, _ := url.Parse("http://unused:9090")
+	mux := buildMuxWithFiles(backendURL, "http://unused:9090", 5*1024*1024, "application/pdf, image/*")
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/config")
+	if err != nil {
+		t.Fatalf("GET /api/config: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := result["maxFileBytes"].(float64); got != 5*1024*1024 {
+		t.Errorf("maxFileBytes = %v, want 5 MiB", got)
+	}
+	mime, ok := result["allowedMime"].([]any)
+	if !ok {
+		t.Fatalf("allowedMime missing or wrong type: %v", result["allowedMime"])
+	}
+	if len(mime) != 2 || mime[0] != "application/pdf" || mime[1] != "image/*" {
+		t.Errorf("allowedMime = %v, want [application/pdf image/*]", mime)
+	}
+}
+
+func TestParseBytes(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   int64
+		errOK  bool
+		errSub string
+	}{
+		{"", defaultMaxFileBytes, false, ""},
+		{"1024", 1024, false, ""},
+		{"5k", 5 * 1024, false, ""},
+		{"5KiB", 5 * 1024, false, ""},
+		{"25m", 25 * 1024 * 1024, false, ""},
+		{"  2 GiB  ", 2 * 1024 * 1024 * 1024, false, ""},
+		{"0", 0, true, "positive"},
+		{"-5", 0, true, "positive"},
+		{"abc", 0, true, "invalid byte count"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseBytes(tc.in, defaultMaxFileBytes)
+			if tc.errOK {
+				if err == nil {
+					t.Fatalf("parseBytes(%q): want error, got %d", tc.in, got)
+				}
+				if tc.errSub != "" && !strings.Contains(err.Error(), tc.errSub) {
+					t.Errorf("parseBytes(%q): error %q, want substring %q", tc.in, err, tc.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBytes(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseBytes(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -250,10 +250,45 @@ const messagesEl = document.getElementById("messages");
 const inputEl = document.getElementById("input");
 const sendBtn = document.getElementById("send-btn");
 const chatEl = document.getElementById("chat");
+const attachBtn = document.getElementById("attach-btn");
+const fileInputEl = document.getElementById("file-input");
+const attachmentsEl = document.getElementById("attachments");
+const dropOverlayEl = document.getElementById("drop-overlay");
+const inputForm = document.getElementById("input-form");
+
+// -- File-upload state ------------------------------------------------------
+// Each entry: {id, file, file_id, status: 'uploading'|'ready'|'failed',
+//              progress: 0..1, error?, xhr?}.  `id` is a client-only key
+//              used to keep DOM nodes in sync; `file_id` is what the
+//              gateway returns and is what we send on the chat request.
+const attachments = [];
+let nextAttachmentId = 1;
+let maxFileBytes = 25 * 1024 * 1024; // mirrors gateway default; replaced from /api/config
+let allowedMimePatterns = null;       // null = allow-all (server is authoritative)
+let dragDepth = 0;                    // dragenter/leave fire on each child; depth-count
+                                      // them so the overlay only hides on the final leave
+
+async function loadUiConfig() {
+  try {
+    const resp = await fetch("/api/config");
+    if (!resp.ok) return;
+    const cfg = await resp.json();
+    if (typeof cfg.maxFileBytes === "number" && cfg.maxFileBytes > 0) {
+      maxFileBytes = cfg.maxFileBytes;
+    }
+    if (Array.isArray(cfg.allowedMime) && cfg.allowedMime.length > 0) {
+      allowedMimePatterns = cfg.allowedMime.map(s => String(s).toLowerCase());
+    }
+  } catch (e) {
+    console.warn("Could not load UI config:", e);
+  }
+}
 
 async function init() {
   setupSettings();
+  await loadUiConfig();
   loadAgentInfo();
+  setupFileUploads();
 }
 
 function appendMessage(role, content) {
@@ -453,8 +488,17 @@ function isBlockElement(html) {
 
 function setStreaming(value) {
   streaming = value;
-  sendBtn.disabled = value;
   inputEl.disabled = value;
+  if (attachBtn) attachBtn.disabled = value;
+  // sendBtn state is owned by updateSendButton (it considers both
+  // streaming and in-flight uploads). When the upload state machine
+  // hasn't been wired yet (early init), fall back to direct disable
+  // so the button reflects streaming immediately.
+  if (typeof updateSendButton === "function") {
+    updateSendButton();
+  } else {
+    sendBtn.disabled = value;
+  }
 }
 
 // -- Per-message stream renderer --------------------------------------------
@@ -1024,9 +1068,334 @@ function showRawResponse(chunks) {
   modal.classList.add("open");
 }
 
+// -- File uploads -----------------------------------------------------------
+
+function setupFileUploads() {
+  attachBtn.addEventListener("click", () => {
+    if (streaming) return;
+    fileInputEl.click();
+  });
+
+  fileInputEl.addEventListener("change", () => {
+    handleFiles(fileInputEl.files);
+    // Reset the input so selecting the same file again still fires `change`.
+    fileInputEl.value = "";
+  });
+
+  // Paste support — clipboard items can include images and arbitrary
+  // files (Finder copy-on-Mac copies the file itself, not just the
+  // path).  Use clipboardData.files when available; otherwise walk
+  // items[] looking for kind === "file".
+  inputEl.addEventListener("paste", (e) => {
+    if (streaming) return;
+    const dt = e.clipboardData;
+    if (!dt) return;
+    const files = pasteFiles(dt);
+    if (files.length > 0) {
+      e.preventDefault();
+      handleFiles(files);
+    }
+  });
+
+  // Drag-and-drop — listen on the form so the overlay covers the
+  // input row + chips.  The overlay itself has pointer-events:none so
+  // it doesn't swallow the drop event.
+  inputForm.addEventListener("dragenter", (e) => {
+    if (streaming) return;
+    if (!hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    dragDepth++;
+    dropOverlayEl.hidden = false;
+  });
+  inputForm.addEventListener("dragover", (e) => {
+    if (streaming) return;
+    if (!hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  });
+  inputForm.addEventListener("dragleave", () => {
+    if (dragDepth > 0) dragDepth--;
+    if (dragDepth === 0) dropOverlayEl.hidden = true;
+  });
+  inputForm.addEventListener("drop", (e) => {
+    dragDepth = 0;
+    dropOverlayEl.hidden = true;
+    if (streaming) return;
+    if (!hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  });
+
+  // Block the browser's default "open this file" behavior anywhere
+  // outside the drop zone, so a missed drop doesn't navigate away
+  // from the chat.
+  window.addEventListener("dragover", (e) => {
+    if (hasFiles(e.dataTransfer)) e.preventDefault();
+  });
+  window.addEventListener("drop", (e) => {
+    if (hasFiles(e.dataTransfer) && e.target !== dropOverlayEl
+        && !inputForm.contains(e.target)) {
+      e.preventDefault();
+    }
+  });
+}
+
+function hasFiles(dt) {
+  if (!dt) return false;
+  // types is a DOMStringList — check via for-of so we don't trip on
+  // browser quirks where indexOf is missing.
+  for (const t of dt.types || []) {
+    if (t === "Files") return true;
+  }
+  return false;
+}
+
+function pasteFiles(dt) {
+  const out = [];
+  if (dt.files && dt.files.length > 0) {
+    for (const f of dt.files) out.push(f);
+    if (out.length > 0) return out;
+  }
+  if (dt.items) {
+    for (const item of dt.items) {
+      if (item.kind === "file") {
+        const f = item.getAsFile();
+        if (f) out.push(f);
+      }
+    }
+  }
+  return out;
+}
+
+function handleFiles(fileList) {
+  for (const file of fileList) {
+    addAttachment(file);
+  }
+}
+
+function addAttachment(file) {
+  const att = {
+    id: "att_" + (nextAttachmentId++),
+    file: file,
+    file_id: null,
+    status: "uploading",
+    progress: 0,
+    error: null,
+    xhr: null,
+  };
+
+  // Pre-flight client-side validation. Cheap checks so the user
+  // doesn't watch a giant file upload only to be 413'd.
+  if (maxFileBytes > 0 && file.size > maxFileBytes) {
+    att.status = "failed";
+    att.error = "File exceeds max size (" + formatBytes(maxFileBytes) + ")";
+  } else if (allowedMimePatterns && !mimeAllowed(file.type, allowedMimePatterns)) {
+    att.status = "failed";
+    att.error = "File type not allowed";
+  }
+
+  attachments.push(att);
+  renderAttachments();
+
+  if (att.status === "uploading") {
+    uploadAttachment(att);
+  }
+  updateSendButton();
+}
+
+function mimeAllowed(ct, patterns) {
+  const norm = (ct || "").toLowerCase().split(";")[0].trim();
+  if (!norm) return false;
+  for (const p of patterns) {
+    if (p === norm) return true;
+    if (p.endsWith("/*") && norm.startsWith(p.slice(0, -1))) return true;
+  }
+  return false;
+}
+
+function uploadAttachment(att) {
+  const fd = new FormData();
+  fd.append("file", att.file, att.file.name);
+
+  const xhr = new XMLHttpRequest();
+  att.xhr = xhr;
+  xhr.open("POST", "/v1/files");
+
+  xhr.upload.addEventListener("progress", (e) => {
+    if (!e.lengthComputable) return;
+    att.progress = e.loaded / e.total;
+    renderAttachments();
+  });
+
+  xhr.addEventListener("load", () => {
+    att.xhr = null;
+    if (xhr.status >= 200 && xhr.status < 300) {
+      try {
+        const body = JSON.parse(xhr.responseText);
+        if (body.file_id) {
+          att.file_id = body.file_id;
+          att.status = "ready";
+          att.progress = 1;
+        } else {
+          att.status = "failed";
+          att.error = "Upload returned no file_id";
+        }
+      } catch (e) {
+        att.status = "failed";
+        att.error = "Could not parse upload response";
+      }
+    } else {
+      att.status = "failed";
+      att.error = describeUploadError(xhr);
+    }
+    renderAttachments();
+    updateSendButton();
+  });
+
+  xhr.addEventListener("error", () => {
+    att.xhr = null;
+    att.status = "failed";
+    att.error = "Network error during upload";
+    renderAttachments();
+    updateSendButton();
+  });
+
+  xhr.addEventListener("abort", () => {
+    att.xhr = null;
+    // Removed by user; nothing to do.
+  });
+
+  xhr.send(fd);
+}
+
+function describeUploadError(xhr) {
+  if (xhr.status === 413) return "File too large";
+  if (xhr.status === 415) return "File type not allowed";
+  if (xhr.status === 422) return "File rejected (virus scan)";
+  if (xhr.status === 0)   return "Upload aborted";
+  // Try to extract a JSON error message; fall back to status text.
+  try {
+    const body = JSON.parse(xhr.responseText);
+    if (body && typeof body.error === "string") return body.error;
+  } catch {}
+  return "Upload failed (HTTP " + xhr.status + ")";
+}
+
+function removeAttachment(id) {
+  const i = attachments.findIndex(a => a.id === id);
+  if (i < 0) return;
+  const att = attachments[i];
+  if (att.xhr) {
+    try { att.xhr.abort(); } catch {}
+  }
+  attachments.splice(i, 1);
+  renderAttachments();
+  updateSendButton();
+}
+
+function renderAttachments() {
+  if (attachments.length === 0) {
+    attachmentsEl.hidden = true;
+    attachmentsEl.replaceChildren();
+    return;
+  }
+  attachmentsEl.hidden = false;
+  attachmentsEl.replaceChildren(...attachments.map(renderChip));
+}
+
+function renderChip(att) {
+  const el = document.createElement("div");
+  el.className = "attachment";
+  if (att.status === "uploading") el.classList.add("uploading");
+  if (att.status === "failed") el.classList.add("failed");
+  el.dataset.id = att.id;
+
+  const icon = document.createElement("span");
+  icon.className = "attachment-icon";
+  icon.innerHTML = fileIconSvg(att.file.type);
+  el.appendChild(icon);
+
+  const name = document.createElement("span");
+  name.className = "attachment-name";
+  name.textContent = att.file.name;
+  name.title = att.file.name;
+  el.appendChild(name);
+
+  const size = document.createElement("span");
+  size.className = "attachment-size";
+  size.textContent = formatBytes(att.file.size);
+  el.appendChild(size);
+
+  if (att.status === "failed" && att.error) {
+    const err = document.createElement("span");
+    err.className = "attachment-error-text";
+    err.textContent = "— " + att.error;
+    err.title = att.error;
+    el.appendChild(err);
+  }
+
+  const remove = document.createElement("button");
+  remove.type = "button";
+  remove.className = "attachment-remove";
+  remove.setAttribute("aria-label", "Remove attachment");
+  remove.textContent = "×";
+  remove.addEventListener("click", () => removeAttachment(att.id));
+  el.appendChild(remove);
+
+  if (att.status === "uploading" || att.status === "failed") {
+    const bar = document.createElement("div");
+    bar.className = "attachment-progress";
+    bar.style.width = Math.max(2, Math.round(att.progress * 100)) + "%";
+    el.appendChild(bar);
+  }
+
+  return el;
+}
+
+function fileIconSvg(mime) {
+  const s = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">`;
+  if (mime && mime.startsWith("image/")) {
+    return s + `<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21,15 16,10 5,21"/></svg>`;
+  }
+  if (mime === "application/pdf") {
+    return s + `<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>`;
+  }
+  return s + `<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="13" x2="15" y2="13"/><line x1="9" y1="17" x2="13" y2="17"/></svg>`;
+}
+
+function formatBytes(n) {
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  if (n < 1024 * 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + " MB";
+  return (n / (1024 * 1024 * 1024)).toFixed(2) + " GB";
+}
+
+function updateSendButton() {
+  // Disable send while any attachment is still uploading. Failed
+  // attachments don't block — the user can either remove them or
+  // send anyway (they're effectively no-ops since they have no
+  // file_id).
+  const anyUploading = attachments.some(a => a.status === "uploading");
+  sendBtn.disabled = streaming || anyUploading;
+}
+
+function readyFileIds() {
+  return attachments.filter(a => a.status === "ready" && a.file_id).map(a => a.file_id);
+}
+
+function clearAttachmentsAfterSend() {
+  attachments.length = 0;
+  renderAttachments();
+  updateSendButton();
+}
+
 async function sendMessage() {
   const text = inputEl.value.trim();
   if (!text || streaming) return;
+  // Refuse to send while uploads are in flight.  setStreaming will
+  // re-disable the send button anyway, but we want a hard refusal
+  // here to avoid racing the upload completion.
+  if (attachments.some(a => a.status === "uploading")) return;
 
   inputEl.value = "";
   autoResize();
@@ -1045,8 +1414,16 @@ async function sendMessage() {
 
   setStreaming(true);
 
+  // Snapshot the file_ids that are ready *now*; don't include
+  // anything that finishes uploading after we've started the
+  // request. Clear the chip list immediately so the user gets visual
+  // feedback that the attachment was consumed.
+  const fileIds = readyFileIds();
+  clearAttachmentsAfterSend();
+
   try {
     const reqBody = { messages: messages, stream: true };
+    if (fileIds.length > 0) reqBody.file_ids = fileIds;
     if (userTemperature !== null) reqBody.temperature = userTemperature;
     if (userMaxTokens !== null) reqBody.max_tokens = userMaxTokens;
     if (userTopP !== null) reqBody.top_p = userTopP;

--- a/static/index.html
+++ b/static/index.html
@@ -120,14 +120,36 @@
   </main>
   <footer>
     <form id="input-form">
-      <textarea id="input" placeholder="Type a message..." rows="1"></textarea>
-      <button type="submit" id="send-btn" title="Send message">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-             stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="22" y1="2" x2="11" y2="13"></line>
-          <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-        </svg>
-      </button>
+      <div id="attachments" class="attachments" hidden></div>
+      <div id="input-row" class="input-row">
+        <button type="button" id="attach-btn" class="attach-btn"
+                title="Attach files" aria-label="Attach files">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
+          </svg>
+        </button>
+        <input type="file" id="file-input" multiple hidden>
+        <textarea id="input" placeholder="Type a message... (drag, paste, or attach files)" rows="1"></textarea>
+        <button type="submit" id="send-btn" title="Send message">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="22" y1="2" x2="11" y2="13"></line>
+            <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+          </svg>
+        </button>
+      </div>
+      <div id="drop-overlay" class="drop-overlay" hidden>
+        <div class="drop-overlay-inner">
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="17 8 12 3 7 8"></polyline>
+            <line x1="12" y1="3" x2="12" y2="15"></line>
+          </svg>
+          <span>Drop files to attach</span>
+        </div>
+      </div>
     </form>
   </footer>
   <script src="app.js"></script>

--- a/static/style.css
+++ b/static/style.css
@@ -197,8 +197,157 @@ footer {
   max-width: var(--max-width);
   margin: 0 auto;
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+
+.input-row {
+  display: flex;
   gap: 8px;
   align-items: flex-end;
+}
+
+.attach-btn {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-bg);
+  color: var(--color-fg-muted, #6b7280);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.attach-btn:hover:not(:disabled) {
+  background: var(--color-bg-elevated, #f3f4f6);
+  color: var(--color-fg, #111827);
+  border-color: var(--color-accent);
+}
+
+.attach-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* -- Attachment chips ----------------------------------------------------- */
+.attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background: var(--color-bg-elevated, #f3f4f6);
+  font-size: 13px;
+  line-height: 1.3;
+  max-width: 280px;
+  position: relative;
+  overflow: hidden;
+}
+
+.attachment.uploading { opacity: 0.85; }
+
+.attachment.failed {
+  border-color: #dc2626;
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.attachment-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.attachment-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+.attachment-size {
+  font-size: 11px;
+  color: var(--color-fg-muted, #6b7280);
+  flex-shrink: 0;
+}
+
+.attachment-remove {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--color-fg-muted, #6b7280);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.attachment-remove:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--color-fg, #111827);
+}
+
+.attachment-progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--color-accent);
+  width: 0;
+  transition: width 0.15s linear;
+}
+
+.attachment.failed .attachment-progress { background: #dc2626; }
+
+.attachment-error-text {
+  font-size: 11px;
+  color: #991b1b;
+  margin-left: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+/* -- Drop overlay --------------------------------------------------------- */
+.drop-overlay {
+  position: absolute;
+  inset: 0;
+  border: 2px dashed var(--color-accent);
+  border-radius: var(--radius);
+  background: rgba(59, 130, 246, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.drop-overlay-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-accent);
+  font-weight: 500;
 }
 
 #input {


### PR DESCRIPTION
## Summary

Closes #16. Adds the full client-side surface of the File Upload track: drag-and-drop, paste, and a file-picker button on the chat input, with progress chips, removal, and `file_ids` plumbed onto chat completions. Pairs with the agent-side endpoints (agent-template#100) and the streaming gateway proxy (gateway-template#11 / PR #32).

## What's new

**Frontend (`static/`)**

- New attach button (paperclip), hidden multi-file `<input>`, and a drop overlay that appears on `dragenter` over the input area. The overlay uses `pointer-events: none` so it doesn't swallow the drop event itself.
- Paste handling on the textarea — clipboard images and arbitrary files trigger an upload alongside the typed message.
- Attachment state machine: each chip tracks `{status: uploading|ready|failed, progress, file_id?, error?}`. Chips render an inline progress bar (XHR `upload.progress` events — `fetch` doesn't expose those) and a remove button. Removing an in-flight upload aborts the XHR.
- `sendMessage` snapshots `readyFileIds()` at submit time, includes them as `file_ids` on the chat-completion request, and clears the chip list immediately so the user sees the attachment was consumed. Send is disabled while any chip is still uploading; failed chips don't block (no `file_id` to send).
- Server-side errors surface as user-friendly text on the chip: 413 → "File too large", 415 → "File type not allowed", 422 → "File rejected (virus scan)", anything else → JSON `error` field or "HTTP NNN".

**Go server (`cmd/server/main.go`)**

- `UI_MAX_FILE_BYTES` (default 25 MiB, mirrors gateway-template's default; supports `k`/`m`/`g` suffixes).
- `UI_ALLOWED_MIME` (optional comma-separated list with `image/*` wildcards).
- Both surfaced through `/api/config` so the JS reads them without extra round-trips. The gateway is the authoritative gate — these knobs only short-circuit obviously-bad uploads in the browser.

**Helm chart**

- New `files` block on `values.yaml`; ConfigMap conditionally emits `UI_MAX_FILE_BYTES` / `UI_ALLOWED_MIME`.

## Tests

- `TestAPIConfig` updated for the new payload shape (`maxFileBytes`, optional `allowedMime`).
- New `TestAPIConfig_FileUploadOverrides` exercises the override path.
- New `TestParseBytes` table-driven across plain bytes, k/m/g suffixes, KiB/MiB/GiB, whitespace, and error cases (zero, negative, garbage).

## Test plan

- [x] `go test ./...` — green
- [x] `go vet ./...` — clean
- [x] `gitleaks` — clean
- [x] `node --check static/app.js` — JS syntax OK
- [x] Smoke against stub backend on :8081: `curl -X POST .../v1/files -F file=@x.pdf` proxied through the UI server returns the stub `file_id`; `/api/config` returns the configured cap + allowlist; new HTML elements (`#attach-btn`, `#file-input`, `#drop-overlay`, `#attachments`) render
- [x] `helm template` renders cleanly with and without the `files` block
- [ ] **Browser-level smoke** (drag, paste, multi-file, abort, oversized, wrong-MIME) — please exercise before merging; this session validated the wiring through curl but did not drive the UI in a real browser

## Notes for reviewer

- The Go test file's `buildMux` duplicates a subset of `main()` (pre-existing pattern, not introduced here). I added `buildMuxWithFiles` rather than refactoring main to share the mux — keeping the diff focused.
- `XMLHttpRequest` was a deliberate choice over `fetch` for upload progress; the latter requires `ReadableStream` upload bodies which still have spotty browser support and don't help here.
- File-icon SVGs are inline (no fetch round-trip, no asset bundle).