### PR TITLE
Add .fips-template.yaml manifest and fix drop overlay visibility

### DIFF
--- a/.fips-template.yaml
+++ b/.fips-template.yaml
@@ -1,0 +1,61 @@
+# fips-agents-cli template manifest.
+#
+# This file declares which paths in the UI template are managed by
+# the template (and so should be offered as patches by `fips-agents
+# patch`) and which belong to the user. The CLI reads this file from
+# the template root after cloning, before computing drift in
+# `fips-agents patch check`.
+#
+# Without this manifest, `fips-agents patch` does not work for UI
+# projects — `get_categories_for_type` in the CLI raises ValueError for
+# gateway / ui / sandbox project types. The presence of this file is
+# what opts the UI template into the patch flow. See:
+#   https://github.com/fips-agents/fips-agents-cli/issues/45
+
+schema_version: 1
+
+patch:
+  categories:
+
+    chart:
+      description: Helm chart templates
+      patterns:
+        - chart/templates/**/*
+        - chart/Chart.yaml
+      ask_before_patch: true
+
+    docs:
+      description: Documentation files
+      patterns:
+        - CLAUDE.md
+        - llms.txt
+        - docs/**/*
+      ask_before_patch: false
+
+    build:
+      description: Build and deployment files
+      patterns:
+        - Makefile
+        - Containerfile
+        - .containerignore
+        - .gitignore
+      ask_before_patch: true
+
+  never_patch:
+    # User's Go entry point
+    - cmd/**
+    # User's Go module dependencies
+    - go.mod
+    # User's deploy values
+    - chart/values.yaml
+    # User-authored planning notes
+    - planning/**
+    # User's web content (HTML/CSS/JS and the embed.go that serves it)
+    - static/**
+    # Tests are user code
+    - "**/*_test.go"
+    # Environment files
+    - .env*
+    # User's README and license
+    - README.md
+    - LICENSE

--- a/static/style.css
+++ b/static/style.css
@@ -341,6 +341,10 @@ footer {
   z-index: 10;
 }
 
+.drop-overlay[hidden] {
+  display: none;
+}
+
 .drop-overlay-inner {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Add `.fips-template.yaml` to opt this repo into the fips-agents patch flow.
- Fix the drop-zone overlay being permanently visible because `.drop-overlay { display: flex }` overrode the UA `[hidden] { display: none }` rule. Closes #28.

## Test plan

- [ ] `make build && make run`, confirm the dashed drop zone is no longer rendered over the input row at idle.
- [ ] Drag a file over the chat — overlay appears; drop or drag-leave — overlay hides.
- [ ] Confirm `.fips-template.yaml` is picked up by `fips-agents` patch tooling.