### PR TITLE
feat: render subagent delegation events in chat UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ The project has two layers:
 - Fetches `/api/config` on load; fetches `/v1/agent-info` to populate a settings panel with model info, parameters, tools, and system prompt
 - Posts to the local `/v1/chat/completions` proxy with `stream: true`
 - Parses SSE responses with streaming display, reasoning/thinking content panel, tool call visualization, and stream metrics (tokens/s, inter-token latency)
+- **Subagent delegation rendering** — handles `delta.subagent` events emitted by fipsagents 0.22.0+ agents that use the subagent-as-tool feature. Renders a delegation card per `span_id` that transitions through `invoked` → `completed` / `failed` states. The subagent's content is folded into the parent assistant message via the parent's normal `content` deltas; the card surfaces only the delegation framing (target agent, task, status, token totals on completion). Style mirrors the existing tool-call pill (`.tool-call` ↔ `.subagent-delegation`).
 - Maintains conversation history in memory
 
 ## Configuration

--- a/static/app.js
+++ b/static/app.js
@@ -523,6 +523,9 @@ function createStreamRenderer(assistantEl) {
   // Per-subagent-delegation state: span_id -> { cardEl, statusEl, footerEl }
   const subagentCards = new Map();
 
+  // Callback invoked when the user clicks an ask_user option button.
+  let questionAnswerCallback = null;
+
   function ensureThinkingPanel() {
     if (thinkingPanel) return;
     thinkingPanel = document.createElement("details");
@@ -712,6 +715,41 @@ function createStreamRenderer(assistantEl) {
     scrollToBottom();
   }
 
+  function renderQuestion(ev) {
+    ensureResponseEl();
+    responseText += ev.question_text;
+    responseEl.innerHTML = renderContent(responseText);
+
+    if (Array.isArray(ev.options) && ev.options.length > 0) {
+      const container = document.createElement("div");
+      container.className = "question-options";
+
+      for (const opt of ev.options) {
+        const label = (typeof opt === "object" && opt !== null && opt.label) ? opt.label : String(opt);
+        const value = (typeof opt === "object" && opt !== null) ? (opt.value !== undefined ? opt.value : opt) : opt;
+
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "question-option-btn";
+        btn.textContent = label;
+        btn.addEventListener("click", function () {
+          if (questionAnswerCallback) {
+            questionAnswerCallback(value);
+          }
+          container.classList.add("answered");
+          for (const b of container.querySelectorAll(".question-option-btn")) {
+            b.disabled = true;
+          }
+        });
+        container.appendChild(btn);
+      }
+
+      assistantEl.appendChild(container);
+    }
+
+    scrollToBottom();
+  }
+
   function appendThinking(text) {
     ensureThinkingPanel();
     thinkingContent.textContent += text;
@@ -847,6 +885,10 @@ function createStreamRenderer(assistantEl) {
           console.debug("[subagent] unhandled type:", sa.type, sa);
         }
       }
+      // Question events (ask_user)
+      if (delta.question && delta.question.type === "asked") {
+        renderQuestion(delta.question);
+      }
       // Assistant content (the user-visible response)
       if (delta.content && delta.role !== "tool") {
         appendContent(delta.content);
@@ -859,6 +901,7 @@ function createStreamRenderer(assistantEl) {
     getResponseText: () => responseText,
     pushRawChunk,
     getRawChunks: () => rawChunks,
+    setQuestionAnswerCallback(fn) { questionAnswerCallback = fn; },
   };
 }
 
@@ -1515,6 +1558,10 @@ async function sendMessage() {
   scrollToBottom();
 
   const renderer = createStreamRenderer(assistantEl);
+  renderer.setQuestionAnswerCallback(function (optionText) {
+    inputEl.value = typeof optionText === "string" ? optionText : JSON.stringify(optionText);
+    setTimeout(() => sendMessage(), 0);
+  });
   const requestStart = performance.now();
   let clientTtft = null;
 

--- a/static/app.js
+++ b/static/app.js
@@ -520,6 +520,9 @@ function createStreamRenderer(assistantEl) {
   // Per-tool state: index -> { pillEl, nameEl, statusEl, argsEl, resultEl, args, name, callId }
   const toolCalls = new Map();
 
+  // Per-subagent-delegation state: span_id -> { cardEl, statusEl, footerEl }
+  const subagentCards = new Map();
+
   function ensureThinkingPanel() {
     if (thinkingPanel) return;
     thinkingPanel = document.createElement("details");
@@ -617,6 +620,95 @@ function createStreamRenderer(assistantEl) {
     match.statusEl.textContent = isError ? "error" : "done";
     match.resultEl.style.display = "block";
     match.resultEl.textContent = content;
+    scrollToBottom();
+  }
+
+  function startSubagentCard(ev) {
+    const card = document.createElement("div");
+    card.className = "subagent-delegation running";
+
+    const header = document.createElement("div");
+    header.className = "subagent-header";
+
+    const icon = document.createElement("span");
+    icon.className = "subagent-icon";
+    icon.textContent = "\u{1F916}"; // robot face
+
+    const nameEl = document.createElement("span");
+    nameEl.className = "subagent-name";
+    nameEl.textContent = ev.agent_name;
+
+    const statusEl = document.createElement("span");
+    statusEl.className = "subagent-status";
+    statusEl.textContent = "delegating…";
+
+    header.appendChild(icon);
+    header.appendChild(nameEl);
+    header.appendChild(statusEl);
+    card.appendChild(header);
+
+    // Task preview — truncated with a <details> toggle for the full text.
+    const task = ev.task || "";
+    const truncated = task.length > 120 ? task.slice(0, 120) + "…" : task;
+    if (task.length > 120) {
+      const taskDetails = document.createElement("details");
+      taskDetails.className = "subagent-task-details";
+      const taskSummary = document.createElement("summary");
+      taskSummary.className = "subagent-task";
+      taskSummary.textContent = truncated;
+      const taskFull = document.createElement("div");
+      taskFull.className = "subagent-task-full";
+      taskFull.textContent = task;
+      taskDetails.appendChild(taskSummary);
+      taskDetails.appendChild(taskFull);
+      card.appendChild(taskDetails);
+    } else if (task) {
+      const taskEl = document.createElement("div");
+      taskEl.className = "subagent-task";
+      taskEl.textContent = task;
+      card.appendChild(taskEl);
+    }
+
+    const footerEl = document.createElement("div");
+    footerEl.className = "subagent-footer";
+    footerEl.style.display = "none";
+    card.appendChild(footerEl);
+
+    assistantEl.appendChild(card);
+    subagentCards.set(ev.span_id, { cardEl: card, statusEl, footerEl });
+    scrollToBottom();
+  }
+
+  function completeSubagentCard(ev) {
+    const entry = subagentCards.get(ev.span_id);
+    if (!entry) return;
+    entry.cardEl.classList.remove("running");
+    entry.cardEl.classList.add("done");
+    entry.statusEl.textContent = "done";
+
+    const tokensUsed = ev.tokens_used || {};
+    const total = (tokensUsed.input_tokens || 0) + (tokensUsed.output_tokens || 0);
+    const parts = [];
+    if (total > 0) parts.push(total.toLocaleString() + " tokens");
+    if (ev.cost_usd != null) parts.push("$" + ev.cost_usd.toFixed(4));
+    if (ev.tool_calls_made != null) parts.push(ev.tool_calls_made + " tool call" + (ev.tool_calls_made === 1 ? "" : "s"));
+    if (parts.length > 0) {
+      entry.footerEl.textContent = parts.join(" · ");
+      entry.footerEl.style.display = "block";
+    }
+    scrollToBottom();
+  }
+
+  function failSubagentCard(ev) {
+    const entry = subagentCards.get(ev.span_id);
+    if (!entry) return;
+    entry.cardEl.classList.remove("running");
+    entry.cardEl.classList.add("error");
+    entry.statusEl.textContent = "failed";
+    if (ev.error_message) {
+      entry.footerEl.textContent = (ev.error_type ? ev.error_type + ": " : "") + ev.error_message;
+      entry.footerEl.style.display = "block";
+    }
     scrollToBottom();
   }
 
@@ -740,6 +832,20 @@ function createStreamRenderer(assistantEl) {
       // Tool execution result (role:"tool" message in the stream)
       if (delta.role === "tool" && delta.tool_call_id) {
         completeToolCall(delta.tool_call_id, delta.content || "", false);
+      }
+      // Subagent delegation events (invoked / completed / failed).
+      // type:"delta" is forward-compat only — log and ignore.
+      if (delta.subagent) {
+        const sa = delta.subagent;
+        if (sa.type === "invoked") {
+          startSubagentCard(sa);
+        } else if (sa.type === "completed") {
+          completeSubagentCard(sa);
+        } else if (sa.type === "failed") {
+          failSubagentCard(sa);
+        } else {
+          console.debug("[subagent] unhandled type:", sa.type, sa);
+        }
       }
       // Assistant content (the user-visible response)
       if (delta.content && delta.role !== "tool") {

--- a/static/style.css
+++ b/static/style.css
@@ -702,6 +702,41 @@ footer {
   color: #b91c1c;
 }
 
+/* Question options -- clickable answer buttons rendered when the agent
+   asks the user a question via ask_user. */
+
+.question-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.question-option-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--color-accent);
+  border-radius: 16px;
+  background: transparent;
+  color: var(--color-accent);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.question-option-btn:hover {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.question-option-btn:active {
+  opacity: 0.8;
+}
+
+.question-option-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /* Response content -- the user-visible final answer. The streaming
    indicator (cursor) is a separate element that lives next to it. */
 .response-content {

--- a/static/style.css
+++ b/static/style.css
@@ -585,6 +585,123 @@ footer {
   color: #b91c1c;
 }
 
+/* Subagent delegation cards — rendered inline in the assistant turn when the
+   agent delegates work to a peer agent. Structurally similar to .tool-call
+   but slightly more prominent (no <details> collapse, wider padding). */
+
+.subagent-delegation {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.6);
+  font-size: 13px;
+  margin: 6px 0;
+}
+
+.subagent-delegation.running {
+  border-color: var(--color-accent);
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.subagent-delegation.done {
+  border-color: #10b981;
+  background: rgba(16, 185, 129, 0.04);
+}
+
+.subagent-delegation.error {
+  border-color: #dc2626;
+  background: rgba(220, 38, 38, 0.04);
+}
+
+.subagent-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.subagent-icon {
+  font-size: 14px;
+}
+
+.subagent-name {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  color: var(--color-text);
+}
+
+.subagent-status {
+  margin-left: auto;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-dim);
+}
+
+.subagent-delegation.running .subagent-status {
+  color: var(--color-accent);
+}
+
+.subagent-delegation.running .subagent-status::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  margin-left: 6px;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.subagent-delegation.done .subagent-status {
+  color: #047857;
+}
+
+.subagent-delegation.error .subagent-status {
+  color: #b91c1c;
+}
+
+.subagent-task {
+  margin-top: 6px;
+  color: var(--color-text-dim);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.subagent-task-details {
+  margin-top: 6px;
+}
+
+.subagent-task-details > summary {
+  color: var(--color-text-dim);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+  list-style: none;
+}
+
+.subagent-task-details > summary::marker,
+.subagent-task-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.subagent-task-full {
+  margin-top: 4px;
+  color: var(--color-text-dim);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.subagent-footer {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--color-text-dim);
+}
+
+.subagent-delegation.error .subagent-footer {
+  color: #b91c1c;
+}
+
 /* Response content -- the user-visible final answer. The streaming
    indicator (cursor) is a separate element that lives next to it. */
 .response-content {


### PR DESCRIPTION
## Summary

Renders the three new \`delta.subagent\` SSE events emitted by fipsagents
0.22.0+ agents that use subagent-as-tool. Without this, the UI sees the
final assistant message but the delegation is invisible.

The wire format (verified against a deployed coordinator/specialist pair):

\`\`\`json
{ \"choices\": [{ \"delta\": {
    \"subagent\": {
      \"type\": \"invoked\" | \"completed\" | \"failed\",
      \"agent_name\": \"...\",
      \"span_id\": \"...\",
      ...
    }
}}] }
\`\`\`

Span IDs correlate \`completed\` / \`failed\` events back to the originating
\`invoked\` event, so concurrent delegations render in parallel.

## Behavior

- **Invoked**: a delegation card unfolds inline showing the target agent
  name, status (\"delegating…\"), and the task (truncated to 120 chars
  with a \`<details>\` toggle for the full string).
- **Completed**: card transitions to \"done\" state. Footer shows total
  tokens and cost. The subagent's \`content\` is **not** rendered in the
  card — it folds into the parent assistant message via normal \`content\`
  deltas so the answer reads naturally.
- **Failed**: card transitions to \"error\" state showing \`error_type\` and
  \`error_message\`.

## What changed

| File | LOC | Shape |
|---|---|---|
| \`static/app.js\` | +106 | Three new helpers (\`startSubagentCard\`, \`completeSubagentCard\`, \`failSubagentCard\`) + a 12-line \`if (delta.subagent)\` dispatch in \`handleDelta()\` |
| \`static/style.css\` | +117 | New \`.subagent-delegation\` ruleset mirroring \`.tool-call\` (per-state border colors, reusing the existing \`pulse\` keyframe) |

Pure additive change. No edits to existing branches in the SSE dispatch,
the message accumulator, or the Go server (which is a verbatim SSE proxy).

## Test plan

- [x] \`make build\` succeeds (Go server embeds the new static files)
- [ ] Visual check against a deployed coordinator/specialist pair on
      OpenShift (target: \`subagent-demo\` namespace on \`mcp-rhoai\` cluster
      with a calculus-coordinator delegating to calculus-agent)
- [ ] Delegation card renders in three states (invoked / completed / failed)
- [ ] Concurrent delegations don't stomp each other (multiple span_ids)

## Related

- agent-template PR #173 — subagent-as-tool v1
- agent-template #179 — v2 streaming nested deltas (will reuse the same card)